### PR TITLE
feat: 实现场景切换自动重连功能

### DIFF
--- a/EscapeFromDuckovCoopMod/Main/NetService.cs
+++ b/EscapeFromDuckovCoopMod/Main/NetService.cs
@@ -36,6 +36,19 @@ public class NetService : MonoBehaviour, INetEventListener
 
     public readonly HashSet<int> _dedupeShotFrame = new(); // 本帧已发过的标记
 
+    // ===== 场景切换重连功能 =====
+    // 缓存成功连接的IP和端口，用于场景切换后自动重连
+    public string cachedConnectedIP = "";
+    public int cachedConnectedPort = 0;
+    public bool hasSuccessfulConnection = false;
+    
+    // 重连防抖机制 - 防止重连触发过于频繁
+    private float lastReconnectTime = 0f;
+    private const float RECONNECT_COOLDOWN = 10f; // 10秒冷却时间
+    
+    // 连接类型标记 - 区分手动连接和自动重连
+    private bool isManualConnection = false; // true: 手动连接(UI点击), false: 自动重连
+
     // 客户端：按 endPoint(玩家ID) 管理
     public readonly Dictionary<string, PlayerStatus> clientPlayerStatuses = new();
     public readonly Dictionary<string, GameObject> clientRemoteCharacters = new();
@@ -67,6 +80,21 @@ public class NetService : MonoBehaviour, INetEventListener
         {
             status = CoopLocalization.Get("net.connectedTo", peer.EndPoint.ToString());
             isConnecting = false;
+            
+            // 只有手动连接成功才更新缓存
+            if (isManualConnection)
+            {
+                cachedConnectedIP = peer.EndPoint.Address.ToString();
+                cachedConnectedPort = peer.EndPoint.Port;
+                hasSuccessfulConnection = true;
+                Debug.Log($"[COOP] 手动连接成功，缓存连接信息: {cachedConnectedIP}:{cachedConnectedPort}");
+                isManualConnection = false; // 重置标记
+            }
+            else
+            {
+                Debug.Log($"[COOP] 自动重连成功，不更新缓存: {peer.EndPoint.Address}:{peer.EndPoint.Port}");
+            }
+            
             Send_ClientStatus.Instance.SendClientStatusUpdate();
         }
 
@@ -155,11 +183,29 @@ public class NetService : MonoBehaviour, INetEventListener
 
     public void OnPeerDisconnected(NetPeer peer, DisconnectInfo disconnectInfo)
     {
-        Debug.Log(CoopLocalization.Get("net.disconnected", peer.EndPoint.ToString(), disconnectInfo.Reason.ToString()));
+        var peerEndPoint = peer?.EndPoint?.ToString() ?? "Unknown";
+        Debug.Log(CoopLocalization.Get("net.disconnected", peerEndPoint, disconnectInfo.Reason.ToString()));
         if (!IsServer)
         {
             status = CoopLocalization.Get("net.connectionLost");
             isConnecting = false;
+            
+            // 只有在手动断开连接时才清除缓存，自动重连失败时保留缓存
+            if (isManualConnection && (disconnectInfo.Reason == DisconnectReason.DisconnectPeerCalled || 
+                disconnectInfo.Reason == DisconnectReason.RemoteConnectionClose))
+            {
+                hasSuccessfulConnection = false;
+                cachedConnectedIP = "";
+                cachedConnectedPort = 0;
+                Debug.Log("[COOP] 手动断开连接，清除缓存的连接信息");
+            }
+            else
+            {
+                Debug.Log($"[COOP] 连接断开 ({disconnectInfo.Reason})，保留缓存的连接信息用于重连");
+            }
+            
+            // 重置手动连接标记
+            isManualConnection = false;
         }
 
         if (connectedPeer == peer) connectedPeer = null;
@@ -167,7 +213,7 @@ public class NetService : MonoBehaviour, INetEventListener
         if (playerStatuses.ContainsKey(peer))
         {
             var _st = playerStatuses[peer];
-            if (_st != null && !string.IsNullOrEmpty(_st.EndPoint))
+            if (_st != null && !string.IsNullOrEmpty(_st.EndPoint) && SceneNet.Instance != null)
                 SceneNet.Instance._cliLastSceneIdByPlayer.Remove(_st.EndPoint);
             playerStatuses.Remove(peer);
         }
@@ -298,6 +344,9 @@ public class NetService : MonoBehaviour, INetEventListener
         networkStarted = false;
         connectedPeer = null;
 
+        // 停止网络时清除缓存的连接信息
+        ClearConnectionCache();
+
         playerStatuses.Clear();
         clientPlayerStatuses.Clear();
 
@@ -318,6 +367,9 @@ public class NetService : MonoBehaviour, INetEventListener
 
     public void ConnectToHost(string ip, int port)
     {
+        // 标记为手动连接（从UI调用）
+        isManualConnection = true;
+        
         // 基础校验
         if (string.IsNullOrWhiteSpace(ip))
         {
@@ -356,6 +408,7 @@ public class NetService : MonoBehaviour, INetEventListener
                 Debug.LogError(CoopLocalization.Get("net.clientNetworkStartFailed", e));
                 status = CoopLocalization.Get("net.clientNetworkStartFailedStatus");
                 isConnecting = false;
+                isManualConnection = false; // 重置手动连接标记
                 return;
             }
 
@@ -364,6 +417,7 @@ public class NetService : MonoBehaviour, INetEventListener
         {
             status = CoopLocalization.Get("net.clientNotStarted");
             isConnecting = false;
+            isManualConnection = false; // 重置手动连接标记
             return;
         }
 
@@ -395,6 +449,7 @@ public class NetService : MonoBehaviour, INetEventListener
             status = CoopLocalization.Get("net.connectionFailed");
             isConnecting = false;
             connectedPeer = null;
+            isManualConnection = false; // 重置手动连接标记
         }
     }
 
@@ -417,5 +472,223 @@ public class NetService : MonoBehaviour, INetEventListener
         if (playerStatuses != null && playerStatuses.TryGetValue(peer, out var st) && !string.IsNullOrEmpty(st.EndPoint))
             return st.EndPoint;
         return peer.EndPoint.ToString();
+    }
+
+    /// <summary>
+    /// 清除缓存的连接信息
+    /// </summary>
+    public void ClearConnectionCache()
+    {
+        hasSuccessfulConnection = false;
+        cachedConnectedIP = "";
+        cachedConnectedPort = 0;
+        Debug.Log("[COOP] 手动清除缓存的连接信息");
+    }
+
+    /// <summary>
+    /// 自动重连方法，不会更新缓存的连接信息
+    /// </summary>
+    private void AutoReconnectToHost(string ip, int port)
+    {
+        // 不标记为手动连接，这样连接成功后不会更新缓存
+        isManualConnection = false;
+        
+        // 基础校验
+        if (string.IsNullOrWhiteSpace(ip))
+        {
+            Debug.LogWarning("[COOP] 自动重连失败：IP为空");
+            return;
+        }
+
+        if (port <= 0 || port > 65535)
+        {
+            Debug.LogWarning("[COOP] 自动重连失败：端口无效");
+            return;
+        }
+
+        if (IsServer)
+        {
+            Debug.LogWarning("[COOP] 服务器模式无法自动重连");
+            return;
+        }
+
+        if (isConnecting)
+        {
+            Debug.LogWarning("[COOP] 正在连接中，跳过自动重连");
+            return;
+        }
+
+        //如未启动或仍在主机模式，则切到"客户端网络"
+        if (netManager == null || !netManager.IsRunning || IsServer || !networkStarted)
+            try
+            {
+                StartNetwork(false); // 启动/切换到客户端模式
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[COOP] 自动重连启动客户端网络失败: {e}");
+                return;
+            }
+
+        // 二次确认
+        if (netManager == null || !netManager.IsRunning)
+        {
+            Debug.LogWarning("[COOP] 自动重连失败：客户端网络未启动");
+            return;
+        }
+
+        try
+        {
+            Debug.Log($"[COOP] 开始自动重连到: {ip}:{port}");
+            isConnecting = true;
+
+            // 若已有连接，先断开（以免残留状态）
+            try
+            {
+                connectedPeer?.Disconnect();
+            }
+            catch
+            {
+            }
+
+            connectedPeer = null;
+
+            if (writer == null) writer = new NetDataWriter();
+
+            writer.Reset();
+            writer.Put("gameKey");
+            netManager.Connect(ip, port, writer);
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"[COOP] 自动重连失败: {ex}");
+            isConnecting = false;
+            connectedPeer = null;
+        }
+    }
+
+    /// <summary>
+    /// 场景加载完成后重新连接到缓存的主机，用于解决切换场景后看不到其他玩家的问题
+    /// </summary>
+    public async UniTask ReconnectAfterSceneLoad()
+    {
+        Debug.Log($"[COOP] ReconnectAfterSceneLoad 被调用 - IsServer: {IsServer}, hasSuccessfulConnection: {hasSuccessfulConnection}");
+        
+        // 只有客户端且有缓存的连接信息才执行重连
+        if (IsServer)
+        {
+            Debug.Log("[COOP] 服务器模式，跳过重连");
+            return;
+        }
+
+        if (!hasSuccessfulConnection)
+        {
+            Debug.Log("[COOP] 没有成功连接的缓存，跳过重连");
+            return;
+        }
+
+        if (string.IsNullOrEmpty(cachedConnectedIP) || cachedConnectedPort <= 0)
+        {
+            Debug.Log($"[COOP] 缓存的连接信息无效 - IP: '{cachedConnectedIP}', Port: {cachedConnectedPort}");
+            return;
+        }
+
+        // 防抖机制：检查是否在冷却时间内
+        float currentTime = Time.realtimeSinceStartup;
+        if (currentTime - lastReconnectTime < RECONNECT_COOLDOWN)
+        {
+            float remainingTime = RECONNECT_COOLDOWN - (currentTime - lastReconnectTime);
+            Debug.Log($"[COOP] 重连冷却中，剩余 {remainingTime:F1} 秒");
+            return;
+        }
+
+        lastReconnectTime = currentTime;
+
+        Debug.Log($"[COOP] 检查当前连接状态 - connectedPeer: {connectedPeer != null}");
+
+        // 强制重连，不跳过任何情况，确保场景切换后的完全同步
+        if (connectedPeer != null && 
+            connectedPeer.EndPoint.Address.ToString() == cachedConnectedIP && 
+            connectedPeer.EndPoint.Port == cachedConnectedPort)
+        {
+            Debug.Log($"[COOP] 检测到已连接到目标主机 {cachedConnectedIP}:{cachedConnectedPort}，但仍然执行重连以确保同步");
+            
+            // 先断开当前连接
+            try
+            {
+                Debug.Log("[COOP] 断开当前连接以准备重连");
+                connectedPeer.Disconnect();
+                connectedPeer = null;
+                await UniTask.Delay(500); // 等待断开完成
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[COOP] 断开连接异常: {ex}");
+            }
+        }
+
+        Debug.Log($"[COOP] 场景加载完成，开始重连到缓存的主机: {cachedConnectedIP}:{cachedConnectedPort}");
+
+        // 等待一小段时间确保场景完全加载
+        await UniTask.Delay(1000);
+
+        try
+        {
+            // 执行自动重连（不会更新缓存）
+            Debug.Log($"[COOP] 调用 AutoReconnectToHost({cachedConnectedIP}, {cachedConnectedPort})");
+            AutoReconnectToHost(cachedConnectedIP, cachedConnectedPort);
+            
+            // 等待连接结果
+            var timeout = Time.realtimeSinceStartup + 15f; // 15秒超时
+            var startTime = Time.realtimeSinceStartup;
+            
+            while (isConnecting && Time.realtimeSinceStartup < timeout)
+            {
+                await UniTask.Delay(100);
+                
+                // 每秒输出一次等待状态
+                if ((int)(Time.realtimeSinceStartup - startTime) % 1 == 0)
+                {
+                    Debug.Log($"[COOP] 等待连接中... 已等待 {(int)(Time.realtimeSinceStartup - startTime)} 秒");
+                }
+            }
+
+            if (connectedPeer != null)
+            {
+                Debug.Log($"[COOP] 场景切换后重连成功: {cachedConnectedIP}:{cachedConnectedPort}");
+                
+                // 重连成功后，发送当前状态进行完全同步
+                await UniTask.Delay(1000); // 等待连接稳定
+                
+                try
+                {
+                    if (Send_ClientStatus.Instance != null)
+                    {
+                        Debug.Log("[COOP] 重连成功，发送客户端状态更新");
+                        Send_ClientStatus.Instance.SendClientStatusUpdate();
+                    }
+                    
+                    // 额外发送场景就绪信息
+                    if (SceneNet.Instance != null)
+                    {
+                        Debug.Log("[COOP] 重连成功，发送场景就绪信息");
+                        SceneNet.Instance.TrySendSceneReadyOnce();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"[COOP] 重连后发送状态更新异常: {ex}");
+                }
+            }
+            else
+            {
+                Debug.LogWarning($"[COOP] 场景切换后重连失败: {cachedConnectedIP}:{cachedConnectedPort}");
+                Debug.LogWarning($"[COOP] isConnecting: {isConnecting}, 超时: {Time.realtimeSinceStartup >= timeout}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"[COOP] 场景切换后重连异常: {ex}");
+        }
     }
 }

--- a/EscapeFromDuckovCoopMod/Main/SceneService/SceneNet.cs
+++ b/EscapeFromDuckovCoopMod/Main/SceneService/SceneNet.cs
@@ -701,6 +701,15 @@ public class SceneNet : MonoBehaviour
         catch
         {
         }
+
+        // ===== 场景切换重连功能 =====
+        // 在Client_SceneGateAsync完成后触发重连，此时服务端已经准备好接受新连接
+        // 这是重连的最佳时机，避免在服务端未准备好时连接失败
+        if (!IsServer && Service != null)
+        {
+            Debug.Log("[COOP] Client_SceneGateAsync 完成，开始重连以确保同步");
+            Service.ReconnectAfterSceneLoad().Forget();
+        }
     }
 
     // 主机：自身初始化完成 → 开门；已举手的立即放行；之后若有迟到的 READY，也会单放行


### PR DESCRIPTION
#34 
- 添加连接信息缓存机制，记录成功的手动连接IP和端口
- 在Client_SceneGateAsync完成后触发重连，确保服务端准备就绪
- 区分用户手动修改ui上的地址手动连接和自动重连，保护缓存信息不被误清除


解决问题:
- 多人游戏中场景切换后看不到其他玩家
- 多人游戏中场景切换后开枪无子弹,近战跳数值但实际上不掉血等攻击无效问题
