### PR TITLE
feat: 新增STEAMP2P联机(混合/虚拟)

### DIFF
--- a/EscapeFromDuckovCoopMod/EscapeFromDuckovCoopMod.csproj
+++ b/EscapeFromDuckovCoopMod/EscapeFromDuckovCoopMod.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Main\SceneService\SceneM.cs" />
     <Compile Include="Main\SceneService\SceneNet.cs" />
     <Compile Include="Main\UI\ModUI.cs" />
+    <Compile Include="Main\UI\ModUI_SteamUI.cs" />
     <Compile Include="Main\Weapon_\GrenadeM.cs" />
     <Compile Include="Main\Weapon_\WeaponHandle.cs" />
     <Compile Include="Main\Weapon_\WeaponRequest.cs" />
@@ -94,7 +95,15 @@
     <Compile Include="Net\NetPack\NetPack_Projectile.cs" />
     <Compile Include="Net\NetPack\PackFlag.cs" />
     <Compile Include="Net\NetSilenceGuards.cs" />
+    <Compile Include="Net\Steam\SteamNetworkingSocketsManager.cs" />
+    <Compile Include="Net\Steam\SteamNetworkTransport.cs" />
+    <Compile Include="Net\Steam\HybridNetworkService.cs" />
+    <Compile Include="Net\Steam\SteamP2PLoader.cs" />
     <Compile Include="Net\Steam\SteamP2PManager.cs" />
+    <Compile Include="Net\Steam\SteamEndPointMapper.cs" />
+    <Compile Include="Net\Steam\SteamLobbyManager.cs" />
+    <Compile Include="Net\Steam\SteamLobbyHelper.cs" />
+    <Compile Include="Net\Steam\SteamLobbyOptions.cs" />
     <Compile Include="Patch\Character_\AICharacterControllerPatch.cs" />
     <Compile Include="Patch\Character_\AnimPacth.cs" />
     <Compile Include="Patch\Character_\BuffPatch.cs" />
@@ -118,6 +127,9 @@
     <Compile Include="Patch\Scene\DoorPatch.cs" />
     <Compile Include="Patch\Scene\LevelManagerPatch.cs" />
     <Compile Include="Patch\Scene\ScenePatch.cs" />
+    <Compile Include="Patch\SteamP2P\PacketSignature.cs" />
+    <Compile Include="Patch\SteamP2P\Patch_Socket.cs" />
+    <Compile Include="Patch\SteamP2P\Patch_LiteNetLib.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SyncData\SyncDataManger.cs" />
     <Compile Include="_BuffLateBinder.cs" />

--- a/EscapeFromDuckovCoopMod/Main/AI/AIName.cs
+++ b/EscapeFromDuckovCoopMod/Main/AI/AIName.cs
@@ -42,8 +42,8 @@ namespace EscapeFromDuckovCoopMod
         private static NetPeer connectedPeer => Service?.connectedPeer;
         private static PlayerStatus localPlayerStatus => Service?.localPlayerStatus;
         private static bool networkStarted => Service != null && Service.networkStarted;
-        private static Dictionary<NetPeer, GameObject> remoteCharacters => Service?.remoteCharacters;
-        private static Dictionary<NetPeer, PlayerStatus> playerStatuses => Service?.playerStatuses;
+        private static Dictionary<string, GameObject> remoteCharacters => Service?.remoteCharacters;
+        private static Dictionary<string, PlayerStatus> playerStatuses => Service?.playerStatuses;
         private static Dictionary<string, GameObject> clientRemoteCharacters => Service?.clientRemoteCharacters;
         private static readonly Dictionary<int, string> _aiFaceJsonById = new Dictionary<int, string>();
 
@@ -231,7 +231,7 @@ namespace EscapeFromDuckovCoopMod
                               || (CharacterIconTypes)iconType == CharacterIconTypes.elete);
                         tag.nameOverride = displayNameFromHost ?? string.Empty;
 
-                        Debug.Log($"[AI_icon_Name 10s] {cmc.GetComponent<NetAiTag>().aiId} {cmc.characterPreset.Name} {cmc.characterPreset.GetCharacterIcon().name}");
+                        Debug.Log("[AI_icon_Name 10s] " + cmc.GetComponent<NetAiTag>().aiId + " " + cmc.characterPreset.Name + " " + cmc.characterPreset.GetCharacterIcon().name);
                         break; // 成功一次即可
                     }
                 }
@@ -303,8 +303,8 @@ namespace EscapeFromDuckovCoopMod
                 // 仅当“有图标”或“需要显示名字”时才重播，避免无意义带宽
                 if (e != global::CharacterIconTypes.none || showName)
                 {
-                        UnityEngine.Debug.Log($"[AI-REBROADCAST-10s] aiId={aiId} icon={e} showName={showName}");
-                   COOPManager.AIHandle.Server_BroadcastAiLoadout(aiId, cmc); // 你现有的方法，里头会把名字一起下发
+                    UnityEngine.Debug.Log("[AI-REBROADCAST-10s] aiId=" + aiId + " icon=" + e + " showName=" + showName);
+                    COOPManager.AIHandle.Server_BroadcastAiLoadout(aiId, cmc);
                 }
             }
         }
@@ -373,7 +373,7 @@ namespace EscapeFromDuckovCoopMod
                 }
             }
             catch { }
-            Debug.Log($"[Server AIIcon_Name 10s] AI:{aiId} {cmc.characterPreset.Name} Icon{(CharacterIconTypes)FR_IconType(cmc.characterPreset)}");
+            Debug.Log("[Server AIIcon_Name 10s] AI:" + aiId + " " + cmc.characterPreset.Name + " Icon" + (CharacterIconTypes)FR_IconType(cmc.characterPreset));
             var w = new NetDataWriter();
             w.Put((byte)Op.AI_NAME_ICON);
             w.Put(aiId);

--- a/EscapeFromDuckovCoopMod/Main/AI/AITool.cs
+++ b/EscapeFromDuckovCoopMod/Main/AI/AITool.cs
@@ -38,8 +38,8 @@ namespace EscapeFromDuckovCoopMod
         private static NetPeer connectedPeer => Service?.connectedPeer;
         private static PlayerStatus localPlayerStatus => Service?.localPlayerStatus;
         private static bool networkStarted => Service != null && Service.networkStarted;
-        private static Dictionary<NetPeer, GameObject> remoteCharacters => Service?.remoteCharacters;
-        private static Dictionary<NetPeer, PlayerStatus> playerStatuses => Service?.playerStatuses;
+        private static Dictionary<string, GameObject> remoteCharacters => Service?.remoteCharacters;
+        private static Dictionary<string, PlayerStatus> playerStatuses => Service?.playerStatuses;
         private static Dictionary<string, GameObject> clientRemoteCharacters => Service?.clientRemoteCharacters;
         public static readonly Dictionary<int, CharacterMainControl> aiById = new Dictionary<int, CharacterMainControl>();
 
@@ -81,7 +81,7 @@ namespace EscapeFromDuckovCoopMod
             int qz = Mathf.RoundToInt(p.z * 10f);
 
             // 名称 + 位置 + 场景索引 → FNV1a
-            string key = $"{sceneIndex}:{r.name}:{qx},{qy},{qz}";
+            string key = sceneIndex + ":" + r.name + ":" + qx + "," + qy + "," + qz;
             return StableHash(key);
         }
 
@@ -105,7 +105,7 @@ namespace EscapeFromDuckovCoopMod
             int qy = Mathf.RoundToInt(p.y * 10f);
             int qz = Mathf.RoundToInt(p.z * 10f);
 
-            string key = $"{sceneIndex}:{r.name}:{qx},{qy},{qz}";
+            string key = sceneIndex + ":" + r.name + ":" + qx + "," + qy + "," + qz;
             return StableHash(key);
         }
 
@@ -309,7 +309,7 @@ namespace EscapeFromDuckovCoopMod
                 }
                 catch (Exception ex)
                 {
-                    Debug.LogError($"获取槽位 {slotNames[i]} 时发生错误: {ex.Message}");
+                    Debug.LogError("获取槽位 " + slotNames[i] + " 时发生错误: " + ex.Message);
                 }
             }
 

--- a/EscapeFromDuckovCoopMod/Main/ClientService/ClientPlayer_Apply.cs
+++ b/EscapeFromDuckovCoopMod/Main/ClientService/ClientPlayer_Apply.cs
@@ -36,8 +36,8 @@ namespace EscapeFromDuckovCoopMod
         private NetPeer connectedPeer => Service?.connectedPeer;
         private PlayerStatus localPlayerStatus => Service?.localPlayerStatus;
         private bool networkStarted => Service != null && Service.networkStarted;
-        private Dictionary<NetPeer, GameObject> remoteCharacters => Service?.remoteCharacters;
-        private Dictionary<NetPeer, PlayerStatus> playerStatuses => Service?.playerStatuses;
+        private Dictionary<string, GameObject> remoteCharacters => Service?.remoteCharacters;
+        private Dictionary<string, PlayerStatus> playerStatuses => Service?.playerStatuses;
         private Dictionary<string, GameObject> clientRemoteCharacters => Service?.clientRemoteCharacters;
         private const float WeaponApplyDebounce = 0.20f; // 200ms 去抖窗口
 
@@ -79,7 +79,7 @@ namespace EscapeFromDuckovCoopMod
                     var item = await COOPManager.GetItemAsync(ids);
                     if (item == null)
                     {
-                        Debug.LogWarning($"无法获取物品: ItemId={itemId}，槽位 {slotHash} 未更新");
+                        Debug.LogWarning("无法获取物品: ItemId=" + itemId + "，槽位 " + slotHash + " 未更新");
                     }
                     if (slotHash == 100)
                     {
@@ -122,7 +122,7 @@ namespace EscapeFromDuckovCoopMod
             }
             catch (Exception ex)
             {
-                Debug.LogError($"更新装备失败(客户端): {playerId}, SlotHash={slotHash}, ItemId={itemId}, 错误: {ex.Message}");
+                Debug.LogError("更新装备失败(客户端): " + playerId + ", SlotHash=" + slotHash + ", ItemId=" + itemId + ", 错误: " + ex.Message);
             }
         }
 
@@ -136,7 +136,7 @@ namespace EscapeFromDuckovCoopMod
             var model = cm ? cm.characterModel : null;
             if (model == null) return;
 
-            string key = $"{playerId}:{slotHash}";
+            string key = playerId + ":" + slotHash.ToString();
             string want = itemId ?? string.Empty;
             if (_lastWeaponAppliedByPlayer.TryGetValue(key, out var last) && last == want)
             {
@@ -181,7 +181,7 @@ namespace EscapeFromDuckovCoopMod
             }
             catch (Exception ex)
             {
-                Debug.LogError($"更新武器失败(客户端): {playerId}, Slot={socket}, ItemId={itemId}, 错误: {ex.Message}");
+                Debug.LogError("更新武器失败(客户端): " + playerId + ", Slot=" + socket + ", ItemId=" + itemId + ", 错误: " + ex.Message);
             }
         }
 

--- a/EscapeFromDuckovCoopMod/Main/ClientService/Sned_ClientStatus.cs
+++ b/EscapeFromDuckovCoopMod/Main/ClientService/Sned_ClientStatus.cs
@@ -44,7 +44,13 @@ namespace EscapeFromDuckovCoopMod
 
         public void SendClientStatusUpdate()
         {
-            if (IsServer || connectedPeer == null) return;
+            if (IsServer) return;
+
+            if (writer == null)
+            {
+                Debug.LogWarning("[SendClientStatusUpdate] writer is null");
+                return;
+            }
 
             localPlayerStatus.CustomFaceJson = CustomFace.LoadLocalCustomFaceJson();
             var equipmentList = LoaclPlayerManager.Instance.GetLocalEquipment();
@@ -68,7 +74,18 @@ namespace EscapeFromDuckovCoopMod
             writer.Put(weaponList.Count);
             foreach (var w in weaponList) w.Serialize(writer);
 
-            connectedPeer.Send(writer, DeliveryMethod.ReliableOrdered);
+            if (connectedPeer != null)
+            {
+                connectedPeer.Send(writer, DeliveryMethod.ReliableOrdered);
+            }
+            else
+            {
+                var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                if (hybrid != null && hybrid.IsConnected)
+                {
+                    hybrid.SendData(writer.Data, writer.Length, DeliveryMethod.ReliableOrdered);
+                }
+            }
         }
 
 

--- a/EscapeFromDuckovCoopMod/Main/FxManager.cs
+++ b/EscapeFromDuckovCoopMod/Main/FxManager.cs
@@ -98,8 +98,8 @@ namespace EscapeFromDuckovCoopMod
         private static NetPeer connectedPeer => Service?.connectedPeer;
         private static PlayerStatus localPlayerStatus => Service?.localPlayerStatus;
         private static bool networkStarted => Service != null && Service.networkStarted;
-        private static Dictionary<NetPeer, GameObject> remoteCharacters => Service?.remoteCharacters;
-        private static Dictionary<NetPeer, PlayerStatus> playerStatuses => Service?.playerStatuses;
+        private static Dictionary<string, GameObject> remoteCharacters => Service?.remoteCharacters;
+        private static Dictionary<string, PlayerStatus> playerStatuses => Service?.playerStatuses;
         private static Dictionary<string, GameObject> clientRemoteCharacters => Service?.clientRemoteCharacters;
         static readonly Dictionary<ItemAgent_Gun, GameObject> _muzzleFxByGun = new Dictionary<ItemAgent_Gun, GameObject>();
         static readonly Dictionary<ItemAgent_Gun, ParticleSystem> _shellPsByGun = new Dictionary<ItemAgent_Gun, ParticleSystem>();
@@ -131,13 +131,8 @@ namespace EscapeFromDuckovCoopMod
                 {
                     if (IsServer)
                     {
-                        // Server：EndPoint -> NetPeer -> remoteCharacters
-                        NetPeer foundPeer = null;
-                        foreach (var kv in playerStatuses)
-                        {
-                            if (kv.Value != null && kv.Value.EndPoint == shooterId) { foundPeer = kv.Key; break; }
-                        }
-                        if (foundPeer != null) remoteCharacters.TryGetValue(foundPeer, out shooterGo);
+                        // Server：直接用 shooterId (EndPoint) 查远端克隆
+                        remoteCharacters.TryGetValue(shooterId, out shooterGo);
                     }
                     else
                     {

--- a/EscapeFromDuckovCoopMod/Main/Health/HurtM.cs
+++ b/EscapeFromDuckovCoopMod/Main/Health/HurtM.cs
@@ -78,7 +78,19 @@ namespace EscapeFromDuckovCoopMod
                 dmg.damagePoint, dmg.damageNormal, dmg.fromWeaponItemID, dmg.bleedChance, dmg.isExplosion,
                 0f
             );
-            connectedPeer.Send(w, DeliveryMethod.ReliableOrdered);
+            
+            if (connectedPeer != null)
+            {
+                connectedPeer.Send(w, DeliveryMethod.ReliableOrdered);
+            }
+            else
+            {
+                var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                if (hybrid != null && hybrid.IsConnected)
+                {
+                    hybrid.SendData(w.Data, w.Length, DeliveryMethod.ReliableOrdered);
+                }
+            }
         }
 
      

--- a/EscapeFromDuckovCoopMod/Main/HostService/Host_Handle.cs
+++ b/EscapeFromDuckovCoopMod/Main/HostService/Host_Handle.cs
@@ -38,8 +38,8 @@ namespace EscapeFromDuckovCoopMod
         private NetPeer connectedPeer => Service?.connectedPeer;
         private PlayerStatus localPlayerStatus => Service?.localPlayerStatus;
         private bool networkStarted => Service != null && Service.networkStarted;
-        private Dictionary<NetPeer, GameObject> remoteCharacters => Service?.remoteCharacters;
-        private Dictionary<NetPeer, PlayerStatus> playerStatuses => Service?.playerStatuses;
+        private Dictionary<string, GameObject> remoteCharacters => Service?.remoteCharacters;
+        private Dictionary<string, PlayerStatus> playerStatuses => Service?.playerStatuses;
         private Dictionary<string, GameObject> clientRemoteCharacters => Service?.clientRemoteCharacters;
         public void Server_HandlePlayerDeadTree(Vector3 pos, Quaternion rot, ItemSnapshot snap)
         {

--- a/EscapeFromDuckovCoopMod/Main/LoaclPlayer/LoaclPlayerManager.cs
+++ b/EscapeFromDuckovCoopMod/Main/LoaclPlayer/LoaclPlayerManager.cs
@@ -38,7 +38,7 @@ namespace EscapeFromDuckovCoopMod
         //public PlayerStatus LocalPlayerStatus => Service?.localPlayerStatus;
         private bool networkStarted => Service != null && Service.networkStarted;
         private int port => Service?.port ?? 0;
-        private Dictionary<NetPeer, GameObject> remoteCharacters => Service?.remoteCharacters;
+        private Dictionary<string, GameObject> remoteCharacters => Service?.remoteCharacters;
         private Dictionary<string, GameObject> clientRemoteCharacters => Service?.clientRemoteCharacters;
         // weaponTypeId(= Item.TypeID) -> projectile prefab
         public readonly Dictionary<int, Projectile> _projCacheByWeaponType = new Dictionary<int, Projectile>();
@@ -68,7 +68,7 @@ namespace EscapeFromDuckovCoopMod
             Service.localPlayerStatus = new PlayerStatus
             {
 
-                EndPoint = IsServer ? $"Host:{port}" : $"Client:{Guid.NewGuid().ToString().Substring(0, 8)}",
+                EndPoint = IsServer ? ("Host:" + port) : ("Client:" + Guid.NewGuid().ToString().Substring(0, 8)),
                 PlayerName = IsServer ? "Host" : "Client",
                 Latency = 0,
                 IsInGame = bool1,
@@ -146,7 +146,7 @@ namespace EscapeFromDuckovCoopMod
                 }
                 catch (Exception ex)
                 {
-                    Debug.LogError($"获取槽位 {slotNames[i]} 时发生错误: {ex.Message}");
+                    Debug.LogError("获取槽位 " + slotNames[i] + " 时发生错误: " + ex.Message);
                 }
             }
 
@@ -177,7 +177,7 @@ namespace EscapeFromDuckovCoopMod
             }
             catch (Exception ex)
             {
-                Debug.LogError($"获取本地武器数据时发生错误: {ex.Message}");
+                Debug.LogError("获取本地武器数据时发生错误: " + ex.Message);
             }
 
             return weaponList;

--- a/EscapeFromDuckovCoopMod/Main/LoaclPlayer/Send_LoaclPlayerStatus.cs
+++ b/EscapeFromDuckovCoopMod/Main/LoaclPlayer/Send_LoaclPlayerStatus.cs
@@ -36,7 +36,7 @@ namespace EscapeFromDuckovCoopMod
         private NetPeer connectedPeer => Service?.connectedPeer;
         private PlayerStatus localPlayerStatus => Service?.localPlayerStatus;
         private bool networkStarted => Service != null && Service.networkStarted;
-        private Dictionary<NetPeer, PlayerStatus> playerStatuses => Service?.playerStatuses;
+        private Dictionary<string, PlayerStatus> playerStatuses => Service?.playerStatuses;
         public void Init()
         {
             Instance = this;
@@ -44,6 +44,12 @@ namespace EscapeFromDuckovCoopMod
         public void SendPlayerStatusUpdate()
         {
             if (!IsServer) return;
+
+            if (writer == null)
+            {
+                Debug.LogWarning("[SendPlayerStatusUpdate] writer is null");
+                return;
+            }
 
             var statuses = new List<PlayerStatus> { localPlayerStatus };
             foreach (var kvp in playerStatuses) statuses.Add(kvp.Value);
@@ -75,13 +81,30 @@ namespace EscapeFromDuckovCoopMod
                 foreach (var w in weaponList) w.Serialize(writer);
             }
 
-            netManager.SendToAll(writer, DeliveryMethod.ReliableOrdered);
+            if (netManager != null)
+            {
+                netManager.SendToAll(writer, DeliveryMethod.ReliableOrdered);
+            }
+            else
+            {
+                var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                if (hybrid != null && hybrid.IsConnected)
+                {
+                    hybrid.BroadcastData(writer.Data, writer.Length, DeliveryMethod.ReliableOrdered);
+                }
+            }
         }
 
 
         public void SendPositionUpdate()
         {
             if (localPlayerStatus == null || !networkStarted) return;
+
+            if (writer == null)
+            {
+                Debug.LogWarning("[SendPositionUpdate] writer is null");
+                return;
+            }
 
             var main = CharacterMainControl.Main;
             if (!main) return;
@@ -93,6 +116,11 @@ namespace EscapeFromDuckovCoopMod
             Vector3 fwd = mr ? mr.forward : tr.forward;
             if (fwd.sqrMagnitude < 1e-12f) fwd = Vector3.forward;
 
+            // 诊断：追踪客户端发送位置
+            if (!IsServer && Time.frameCount % 120 == 0) // 每2秒记录一次
+            {
+                Debug.Log("[客户端发包] SendPositionUpdate pos=" + pos);
+            }
 
             writer.Reset();
             writer.Put((byte)Op.POSITION_UPDATE);
@@ -102,13 +130,47 @@ namespace EscapeFromDuckovCoopMod
             NetPack.PutV3cm(writer, pos);
             NetPack.PutDir(writer, fwd);
 
-            if (IsServer) netManager.SendToAll(writer, DeliveryMethod.Unreliable);
-            else connectedPeer?.Send(writer, DeliveryMethod.Unreliable);
+            if (IsServer)
+            {
+                if (netManager != null)
+                {
+                    netManager.SendToAll(writer, DeliveryMethod.Unreliable);
+                }
+                else
+                {
+                    var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                    if (hybrid != null && hybrid.IsConnected)
+                    {
+                        hybrid.BroadcastData(writer.Data, writer.Length, DeliveryMethod.Unreliable);
+                    }
+                }
+            }
+            else
+            {
+                if (connectedPeer != null)
+                {
+                    connectedPeer.Send(writer, DeliveryMethod.Unreliable);
+                }
+                else
+                {
+                    var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                    if (hybrid != null && hybrid.IsConnected)
+                    {
+                        hybrid.SendData(writer.Data, writer.Length, DeliveryMethod.Unreliable);
+                    }
+                }
+            }
         }
 
         public void SendEquipmentUpdate(EquipmentSyncData equipmentData)
         {
             if (localPlayerStatus == null || !networkStarted) return;
+
+            if (writer == null)
+            {
+                Debug.LogWarning("[SendEquipmentUpdate] writer is null");
+                return;
+            }
 
             writer.Reset();
             writer.Put((byte)Op.EQUIPMENT_UPDATE);
@@ -116,8 +178,36 @@ namespace EscapeFromDuckovCoopMod
             writer.Put(equipmentData.SlotHash);
             writer.Put(equipmentData.ItemId ?? "");
 
-            if (IsServer) netManager.SendToAll(writer, DeliveryMethod.ReliableOrdered);
-            else connectedPeer?.Send(writer, DeliveryMethod.ReliableOrdered);
+            if (IsServer)
+            {
+                if (netManager != null)
+                {
+                    netManager.SendToAll(writer, DeliveryMethod.ReliableOrdered);
+                }
+                else
+                {
+                    var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                    if (hybrid != null && hybrid.IsConnected)
+                    {
+                        hybrid.BroadcastData(writer.Data, writer.Length, DeliveryMethod.ReliableOrdered);
+                    }
+                }
+            }
+            else
+            {
+                if (connectedPeer != null)
+                {
+                    connectedPeer.Send(writer, DeliveryMethod.ReliableOrdered);
+                }
+                else
+                {
+                    var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                    if (hybrid != null && hybrid.IsConnected)
+                    {
+                        hybrid.SendData(writer.Data, writer.Length, DeliveryMethod.ReliableOrdered);
+                    }
+                }
+            }
         }
 
 
@@ -125,19 +215,59 @@ namespace EscapeFromDuckovCoopMod
         {
             if (localPlayerStatus == null || !networkStarted) return;
 
+            if (writer == null)
+            {
+                Debug.LogWarning("[SendWeaponUpdate] writer is null");
+                return;
+            }
+
             writer.Reset();
             writer.Put((byte)Op.PLAYERWEAPON_UPDATE);    // opcode
             writer.Put(localPlayerStatus.EndPoint);
             writer.Put(weaponSyncData.SlotHash);
             writer.Put(weaponSyncData.ItemId ?? "");
 
-            if (IsServer) netManager.SendToAll(writer, DeliveryMethod.ReliableOrdered);
-            else connectedPeer?.Send(writer, DeliveryMethod.ReliableOrdered);
+            if (IsServer)
+            {
+                if (netManager != null)
+                {
+                    netManager.SendToAll(writer, DeliveryMethod.ReliableOrdered);
+                }
+                else
+                {
+                    var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                    if (hybrid != null && hybrid.IsConnected)
+                    {
+                        hybrid.BroadcastData(writer.Data, writer.Length, DeliveryMethod.ReliableOrdered);
+                    }
+                }
+            }
+            else
+            {
+                if (connectedPeer != null)
+                {
+                    connectedPeer.Send(writer, DeliveryMethod.ReliableOrdered);
+                }
+                else
+                {
+                    var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                    if (hybrid != null && hybrid.IsConnected)
+                    {
+                        hybrid.SendData(writer.Data, writer.Length, DeliveryMethod.ReliableOrdered);
+                    }
+                }
+            }
         }
 
         public void SendAnimationStatus()
         {
             if (!networkStarted) return;
+
+            if (writer == null)
+            {
+                Debug.LogWarning("[SendAnimationStatus] writer is null");
+                return;
+            }
 
             var mainControl = CharacterMainControl.Main;
             if (mainControl == null) return;
@@ -152,6 +282,12 @@ namespace EscapeFromDuckovCoopMod
             var state = anim.GetCurrentAnimatorStateInfo(0);
             int stateHash = state.shortNameHash;
             float normTime = state.normalizedTime;
+            
+            // 诊断：追踪客户端发送动画
+            if (!IsServer && Time.frameCount % 120 == 0) // 每2秒记录一次
+            {
+                Debug.Log("[客户端发包] SendAnimationStatus");
+            }
 
             writer.Reset();
             writer.Put((byte)Op.ANIM_SYNC);                      // opcode
@@ -169,12 +305,23 @@ namespace EscapeFromDuckovCoopMod
                 writer.Put(anim.GetBool("GunReady"));
                 writer.Put(stateHash);
                 writer.Put(normTime);
-                netManager.SendToAll(writer, DeliveryMethod.Sequenced);
+                
+                if (netManager != null)
+                {
+                    netManager.SendToAll(writer, DeliveryMethod.Sequenced);
+                }
+                else
+                {
+                    var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                    if (hybrid != null && hybrid.IsConnected)
+                    {
+                        hybrid.BroadcastData(writer.Data, writer.Length, DeliveryMethod.Sequenced);
+                    }
+                }
             }
             else
             {
                 // 客户端 -> 主机：不带 playerId
-                if (connectedPeer == null) return;
                 writer.Put(anim.GetFloat("MoveSpeed"));
                 writer.Put(anim.GetFloat("MoveDirX"));
                 writer.Put(anim.GetFloat("MoveDirY"));
@@ -184,7 +331,19 @@ namespace EscapeFromDuckovCoopMod
                 writer.Put(anim.GetBool("GunReady"));
                 writer.Put(stateHash);
                 writer.Put(normTime);
-                connectedPeer.Send(writer, DeliveryMethod.Sequenced);
+                
+                if (connectedPeer != null)
+                {
+                    connectedPeer.Send(writer, DeliveryMethod.Sequenced);
+                }
+                else
+                {
+                    var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                    if (hybrid != null && hybrid.IsConnected)
+                    {
+                        hybrid.SendData(writer.Data, writer.Length, DeliveryMethod.Sequenced);
+                    }
+                }
             }
         }
 
@@ -192,7 +351,13 @@ namespace EscapeFromDuckovCoopMod
         public void Net_ReportPlayerDeadTree(CharacterMainControl who)
         {
             // 仅客户端上报；主机不需要发
-            if (!networkStarted || IsServer || connectedPeer == null || who == null) return;
+            if (!networkStarted || IsServer || who == null) return;
+
+            if (writer == null)
+            {
+                Debug.LogWarning("[Net_ReportPlayerDeadTree] writer is null");
+                return;
+            }
 
             var item = who.CharacterItem;            // 本机一定能拿到
             if (item == null) return;
@@ -207,10 +372,21 @@ namespace EscapeFromDuckovCoopMod
             writer.PutV3cm(pos);
             writer.PutQuaternion(rot);
 
-            // 把整棵物品“快照”写进包里
+            // 把整棵物品"快照"写进包里
             ItemTool.WriteItemSnapshot(writer, item);
 
-            connectedPeer.Send(writer, DeliveryMethod.ReliableOrdered);
+            if (connectedPeer != null)
+            {
+                connectedPeer.Send(writer, DeliveryMethod.ReliableOrdered);
+            }
+            else
+            {
+                var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                if (hybrid != null && hybrid.IsConnected)
+                {
+                    hybrid.SendData(writer.Data, writer.Length, DeliveryMethod.ReliableOrdered);
+                }
+            }
         }
 
 

--- a/EscapeFromDuckovCoopMod/Main/LoaclPlayer/Spectator.cs
+++ b/EscapeFromDuckovCoopMod/Main/LoaclPlayer/Spectator.cs
@@ -38,8 +38,8 @@ namespace EscapeFromDuckovCoopMod
         private NetPeer connectedPeer => Service?.connectedPeer;
         private PlayerStatus localPlayerStatus => Service?.localPlayerStatus;
         private bool networkStarted => Service != null && Service.networkStarted;
-        private Dictionary<NetPeer, GameObject> remoteCharacters => Service?.remoteCharacters;
-        private Dictionary<NetPeer, PlayerStatus> playerStatuses => Service?.playerStatuses;
+        private Dictionary<string, GameObject> remoteCharacters => Service?.remoteCharacters;
+        private Dictionary<string, PlayerStatus> playerStatuses => Service?.playerStatuses;
         private Dictionary<string, GameObject> clientRemoteCharacters => Service?.clientRemoteCharacters;
         public bool _spectatorEndOnVotePending = false;
 
@@ -135,7 +135,7 @@ namespace EscapeFromDuckovCoopMod
                 }
             }
 
-            Debug.Log($"[SPECTATE] 候选={cand}, 同图保留={kept}, mySceneId={mySceneId} (canon={myK})");
+            Debug.Log("[SPECTATE] 候选=" + cand + ", 同图保留=" + kept + ", mySceneId=" + mySceneId + " (canon=" + myK + ")");
         }
 
         //说实话这个方法没多大用   //说实话这个方法没多大用   //说实话这个方法没多大用   //说实话这个方法没多大用

--- a/EscapeFromDuckovCoopMod/Main/Loader/Loader.cs
+++ b/EscapeFromDuckovCoopMod/Main/Loader/Loader.cs
@@ -37,6 +37,29 @@ namespace EscapeFromDuckovCoopMod
             DontDestroyOnLoad(go);
 
             go.AddComponent<NetService>();
+            
+            var steamGo = new GameObject("STEAM_NETWORKING_SOCKETS");
+            DontDestroyOnLoad(steamGo);
+            var steamNetSockets = steamGo.AddComponent<EscapeFromDuckovCoopMod.Net.Steam.SteamNetworkingSocketsManager>();
+            var steamTransport = steamGo.AddComponent<EscapeFromDuckovCoopMod.Net.Steam.SteamNetworkTransport>();
+            steamGo.AddComponent<EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService>();
+            
+            if (steamNetSockets != null)
+            {
+                steamNetSockets.Initialize();
+            }
+            
+            if (steamTransport != null)
+            {
+                steamTransport.Initialize();
+            }
+            
+            var p2pGo = new GameObject("STEAM_P2P_VIRTUAL_NETWORK");
+            DontDestroyOnLoad(p2pGo);
+            var p2pLoader = p2pGo.AddComponent<EscapeFromDuckovCoopMod.Net.Steam.SteamP2PLoader>();
+            p2pLoader.Init();
+            Debug.Log("[Mod] Steam P2P虚拟网络系统已初始化");
+            
             COOPManager.InitManager();
             go.AddComponent<EscapeFromDuckovCoopMod.ModBehaviourF>();
             Loader();

--- a/EscapeFromDuckovCoopMod/Main/SceneService/CreateRemoteCharacter.cs
+++ b/EscapeFromDuckovCoopMod/Main/SceneService/CreateRemoteCharacter.cs
@@ -39,12 +39,12 @@ namespace EscapeFromDuckovCoopMod
         private static NetPeer connectedPeer => Service?.connectedPeer;
         private static PlayerStatus localPlayerStatus => Service?.localPlayerStatus;
         private static bool networkStarted => Service != null && Service.networkStarted;
-        private static Dictionary<NetPeer, GameObject> remoteCharacters => Service?.remoteCharacters;
-        private static Dictionary<NetPeer, PlayerStatus> playerStatuses => Service?.playerStatuses;
+        private static Dictionary<string, GameObject> remoteCharacters => Service?.remoteCharacters;
+        private static Dictionary<string, PlayerStatus> playerStatuses => Service?.playerStatuses;
         private static Dictionary<string, GameObject> clientRemoteCharacters => Service?.clientRemoteCharacters;
-        public static async UniTask<GameObject> CreateRemoteCharacterAsync(NetPeer peer, Vector3 position, Quaternion rotation, string customFaceJson)
+        public static async UniTask<GameObject> CreateRemoteCharacterAsync(string endPoint, Vector3 position, Quaternion rotation, string customFaceJson)
         {
-            if (remoteCharacters.ContainsKey(peer) && remoteCharacters[peer] != null) return null;
+            if (remoteCharacters.ContainsKey(endPoint) && remoteCharacters[endPoint] != null) return null;
 
             var levelManager = LevelManager.Instance;
             if (levelManager == null || levelManager.MainCharacter == null) return null;
@@ -103,13 +103,13 @@ namespace EscapeFromDuckovCoopMod
             if (h) h.autoInit = false;            // ★ 阻止 Start()->Init() 把血直接回满
             instance.AddComponent<AutoRequestHealthBar>(); // 你已有就不要重复
                                                            // 主机创建完后立刻挂监听并推一次
-            HealthTool.Server_HookOneHealth(peer, instance);
+            HealthTool.Server_HookOneHealth(endPoint, instance);
             instance.AddComponent<HostForceHealthBar>();
 
             NetInterpUtil.Attach(instance)?.Push(position, rotation);
             AnimInterpUtil.Attach(instance); // 先挂上，样本由后续网络包填
             cmc.gameObject.SetActive(false);
-            remoteCharacters[peer] = instance;
+            remoteCharacters[endPoint] = instance;
             cmc.gameObject.SetActive(true);
             return instance;
         }

--- a/EscapeFromDuckovCoopMod/Main/SceneService/DeadLootBox.cs
+++ b/EscapeFromDuckovCoopMod/Main/SceneService/DeadLootBox.cs
@@ -129,7 +129,7 @@ namespace EscapeFromDuckovCoopMod
             {
                 if (aiId > 0 && AITool.aiById.TryGetValue(aiId, out var cmc) && cmc)
                 {
-                    Debug.LogWarning($"[SpawnDeadloot] AiID:{cmc.GetComponent<NetAiTag>().aiId}");
+                    Debug.LogWarning("[SpawnDeadloot] AiID:" + cmc.GetComponent<NetAiTag>().aiId);
                     if (cmc.deadLootBoxPrefab.gameObject == null)
                     {
                         Debug.LogWarning("[SPawnDead] deadLootBoxPrefab.gameObject null!");
@@ -215,7 +215,19 @@ namespace EscapeFromDuckovCoopMod
                 writer.Put(lootUid);                              // 稳定 ID
                 writer.PutV3cm(box.transform.position);
                 writer.PutQuaternion(box.transform.rotation);
-                netManager.SendToAll(writer, LiteNetLib.DeliveryMethod.ReliableOrdered);
+                
+                if (netManager != null)
+                {
+                    netManager.SendToAll(writer, LiteNetLib.DeliveryMethod.ReliableOrdered);
+                }
+                else
+                {
+                    var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                    if (hybrid != null && hybrid.IsConnected)
+                    {
+                        hybrid.BroadcastData(writer.Data, writer.Length, LiteNetLib.DeliveryMethod.ReliableOrdered);
+                    }
+                }
 
                 if (EAGER_BROADCAST_LOOT_STATE_ON_SPAWN)
                     StartCoroutine(RebroadcastDeadLootStateAfterFill(box));
@@ -253,7 +265,19 @@ namespace EscapeFromDuckovCoopMod
                 writer.Put(UnityEngine.SceneManagement.SceneManager.GetActiveScene().buildIndex);
                 writer.PutV3cm(box.transform.position);
                 writer.PutQuaternion(box.transform.rotation);
-                netManager.SendToAll(writer, LiteNetLib.DeliveryMethod.ReliableOrdered);
+                
+                if (netManager != null)
+                {
+                    netManager.SendToAll(writer, LiteNetLib.DeliveryMethod.ReliableOrdered);
+                }
+                else
+                {
+                    var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                    if (hybrid != null && hybrid.IsConnected)
+                    {
+                        hybrid.BroadcastData(writer.Data, writer.Length, LiteNetLib.DeliveryMethod.ReliableOrdered);
+                    }
+                }
 
                 // 2) 可选：是否立刻广播整箱内容（默认不广播，等客户端真正打开时再按需请求）
                 if (EAGER_BROADCAST_LOOT_STATE_ON_SPAWN)

--- a/EscapeFromDuckovCoopMod/Main/SceneService/Destructible.cs
+++ b/EscapeFromDuckovCoopMod/Main/SceneService/Destructible.cs
@@ -260,7 +260,19 @@ namespace EscapeFromDuckovCoopMod
             // Hit视觉信息足够：点+法线
             w.PutV3cm(dmg.damagePoint);
             w.PutDir(dmg.damageNormal.sqrMagnitude < 1e-6f ? Vector3.forward : dmg.damageNormal.normalized);
-            netManager.SendToAll(w, DeliveryMethod.ReliableOrdered);
+            
+            if (netManager != null)
+            {
+                netManager.SendToAll(w, DeliveryMethod.ReliableOrdered);
+            }
+            else
+            {
+                var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                if (hybrid != null && hybrid.IsConnected)
+                {
+                    hybrid.BroadcastData(w.Data, w.Length, DeliveryMethod.ReliableOrdered);
+                }
+            }
         }
 
         public void Server_BroadcastDestructibleDead(uint id, DamageInfo dmg)
@@ -270,7 +282,19 @@ namespace EscapeFromDuckovCoopMod
             w.Put(id);
             w.PutV3cm(dmg.damagePoint);
             w.PutDir(dmg.damageNormal.sqrMagnitude < 1e-6f ? Vector3.up : dmg.damageNormal.normalized);
-            netManager.SendToAll(w, DeliveryMethod.ReliableOrdered);
+            
+            if (netManager != null)
+            {
+                netManager.SendToAll(w, DeliveryMethod.ReliableOrdered);
+            }
+            else
+            {
+                var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                if (hybrid != null && hybrid.IsConnected)
+                {
+                    hybrid.BroadcastData(w.Data, w.Length, DeliveryMethod.ReliableOrdered);
+                }
+            }
         }
 
         // 客户端：复现受击视觉（不改血量，不触发本地 OnHurt）

--- a/EscapeFromDuckovCoopMod/Main/SceneService/LootNet.cs
+++ b/EscapeFromDuckovCoopMod/Main/SceneService/LootNet.cs
@@ -79,7 +79,18 @@ namespace EscapeFromDuckovCoopMod
             if (!LootManager.Instance.TryGetLootboxWorldPos(lootInv, out pos)) pos = Vector3.zero;
             w.PutV3cm(pos);
 
-            connectedPeer.Send(w, DeliveryMethod.ReliableOrdered);
+            if (connectedPeer != null)
+            {
+                connectedPeer.Send(w, DeliveryMethod.ReliableOrdered);
+            }
+            else
+            {
+                var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                if (hybrid != null && hybrid.IsConnected)
+                {
+                    hybrid.SendData(w.Data, w.Length, DeliveryMethod.ReliableOrdered);
+                }
+            }
         }
 
 
@@ -219,7 +230,7 @@ namespace EscapeFromDuckovCoopMod
                 if (pending && ItemTool.ReferenceEquals(pending, item))
                 {
                     // 已经有一个在途请求了，丢弃重复点击
-                    Debug.Log($"[LOOT] Duplicate PUT suppressed for item: {item.DisplayName}");
+                    Debug.Log("[LOOT] Duplicate PUT suppressed for item: " + item.DisplayName);
                     return;
                 }
             }
@@ -235,7 +246,19 @@ namespace EscapeFromDuckovCoopMod
             w.Put(preferPos);
             w.Put(token);
             ItemTool.WriteItemSnapshot(w, item);
-            connectedPeer.Send(w, DeliveryMethod.ReliableOrdered);
+            
+            if (connectedPeer != null)
+            {
+                connectedPeer.Send(w, DeliveryMethod.ReliableOrdered);
+            }
+            else
+            {
+                var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                if (hybrid != null && hybrid.IsConnected)
+                {
+                    hybrid.SendData(w.Data, w.Length, DeliveryMethod.ReliableOrdered);
+                }
+            }
         }
 
 
@@ -303,13 +326,13 @@ namespace EscapeFromDuckovCoopMod
             }
             catch (DecoderFallbackException ex)
             {
-                Debug.LogError($"[LOOT][PUT] snapshot decode failed: {ex.Message}");
+                Debug.LogError("[LOOT][PUT] snapshot decode failed: " + ex.Message);
                 Server_SendLootDeny(peer, "bad_snapshot");
                 return;
             }
             catch (Exception ex)
             {
-                Debug.LogError($"[LOOT][PUT] snapshot parse failed: {ex}");
+                Debug.LogError("[LOOT][PUT] snapshot parse failed: " + ex);
                 Server_SendLootDeny(peer, "bad_snapshot");
                 return;
             }
@@ -339,7 +362,7 @@ namespace EscapeFromDuckovCoopMod
             }
             catch (Exception ex)
             {
-                Debug.LogError($"[LOOT][PUT] AddAndMerge exception: {ex}");
+                Debug.LogError("[LOOT][PUT] AddAndMerge exception: " + ex);
                 ok = false;
             }
             finally { _serverApplyingLoot = false; }
@@ -720,7 +743,7 @@ namespace EscapeFromDuckovCoopMod
             }
             catch (System.Exception ex)
             {
-                Debug.LogError($"[LOOT][PLUG] {ex}");
+                Debug.LogError("[LOOT][PLUG] " + ex);
                 ok = false;
             }
             finally { _serverApplyingLoot = false; }
@@ -909,7 +932,7 @@ namespace EscapeFromDuckovCoopMod
             }
             catch (System.Exception ex)
             {
-                Debug.LogError($"[LOOT][UNPLUG] {ex}");
+                Debug.LogError("[LOOT][UNPLUG] " + ex);
                 ok = false;
             }
             finally { _serverApplyingLoot = false; }

--- a/EscapeFromDuckovCoopMod/Main/SceneService/SceneM.cs
+++ b/EscapeFromDuckovCoopMod/Main/SceneService/SceneM.cs
@@ -37,10 +37,10 @@ namespace EscapeFromDuckovCoopMod
         private static NetPeer connectedPeer => Service?.connectedPeer;
         private static PlayerStatus localPlayerStatus => Service?.localPlayerStatus;
         private static bool networkStarted => Service != null && Service.networkStarted;
-        private static Dictionary<NetPeer, GameObject> remoteCharacters => Service?.remoteCharacters;
-        private static Dictionary<NetPeer, PlayerStatus> playerStatuses => Service?.playerStatuses;
+        private static Dictionary<string, GameObject> remoteCharacters => Service?.remoteCharacters;
+        private static Dictionary<string, PlayerStatus> playerStatuses => Service?.playerStatuses;
         private static Dictionary<string, GameObject> clientRemoteCharacters => Service?.clientRemoteCharacters;
-        public static readonly Dictionary<NetPeer, string> _srvPeerScene = new Dictionary<NetPeer, string>();
+        public static readonly Dictionary<string, string> _srvPeerScene = new Dictionary<string, string>();
 
 
         // —— 仅统计“本地图”的存活玩家；本机已死时就看同图是否还有活人 —— 
@@ -130,8 +130,9 @@ namespace EscapeFromDuckovCoopMod
 
             foreach (var p in netManager.ConnectedPeerList)
             {
+                string endPoint = p.EndPoint.ToString();
                 string peerScene = null;
-                if (!_srvPeerScene.TryGetValue(p, out peerScene) && playerStatuses.TryGetValue(p, out var st))
+                if (!_srvPeerScene.TryGetValue(endPoint, out peerScene) && playerStatuses.TryGetValue(endPoint, out var st))
                     peerScene = st.SceneId;
 
                 if (!string.IsNullOrEmpty(peerScene) && peerScene == hostSceneId)

--- a/EscapeFromDuckovCoopMod/Main/UI/ModUI_SteamUI.cs
+++ b/EscapeFromDuckovCoopMod/Main/UI/ModUI_SteamUI.cs
@@ -1,0 +1,311 @@
+using System.Collections.Generic;
+using UnityEngine;
+using Steamworks;
+
+namespace EscapeFromDuckovCoopMod
+{
+    public partial class ModUI
+    {
+        private void DrawSteamUserInfo()
+        {
+            if (SteamManager.Initialized)
+            {
+                GUILayout.BeginVertical(GUI.skin.box);
+                GUILayout.Label("Steam 用户信息", GUI.skin.box);
+                string steamName = SteamFriends.GetPersonaName();
+                CSteamID steamId = SteamUser.GetSteamID();
+                GUILayout.Label("用户名: " + steamName);
+                GUILayout.Label("Steam ID: " + steamId.m_SteamID);
+                GUILayout.EndVertical();
+                GUILayout.Space(5);
+            }
+        }
+        
+        private void DrawSteamPlayerList()
+        {
+            var steamNet = EscapeFromDuckovCoopMod.Net.Steam.SteamNetworkingSocketsManager.Instance;
+            if (steamNet == null || !steamNet.LobbyId.IsValid()) return;
+            
+            GUILayout.BeginVertical(GUI.skin.box);
+            
+            int memberCount = SteamMatchmaking.GetNumLobbyMembers(steamNet.LobbyId);
+            int connectedCount = steamNet.ConnectedPeerCount;
+            
+            GUILayout.Label("在线玩家列表", GUI.skin.box);
+            GUILayout.Label("大厅成员: " + memberCount + " | P2P已连接: " + connectedCount);
+            GUILayout.Space(3);
+            
+            playerListScrollPos = GUILayout.BeginScrollView(playerListScrollPos, GUILayout.Height(200));
+            
+            for (int i = 0; i < memberCount; i++)
+            {
+                CSteamID memberId = SteamMatchmaking.GetLobbyMemberByIndex(steamNet.LobbyId, i);
+                string memberName = SteamFriends.GetFriendPersonaName(memberId);
+                bool isOwner = memberId == SteamMatchmaking.GetLobbyOwner(steamNet.LobbyId);
+                CSteamID localSteamId = SteamUser.GetSteamID();
+                bool isLocalPlayer = memberId == localSteamId;
+                
+                bool isP2PConnected = steamNet.IsP2PConnected(memberId);
+                string connectionStatus = steamNet.GetConnectionStatus(memberId);
+                
+                Steamworks.EPersonaState playerState = SteamFriends.GetFriendPersonaState(memberId);
+                bool isInGame = playerState == Steamworks.EPersonaState.k_EPersonaStateOnline || 
+                                playerState == Steamworks.EPersonaState.k_EPersonaStateBusy || 
+                                playerState == Steamworks.EPersonaState.k_EPersonaStateLookingToPlay || 
+                                playerState == Steamworks.EPersonaState.k_EPersonaStateLookingToTrade;
+                
+                GUILayout.BeginVertical(GUI.skin.box);
+                
+                Color oldColor = GUI.color;
+                if (isOwner)
+                {
+                    GUI.color = Color.yellow;
+                }
+                else if (isLocalPlayer)
+                {
+                    GUI.color = Color.cyan;
+                }
+                else if (isP2PConnected)
+                {
+                    GUI.color = Color.green;
+                }
+                else
+                {
+                    GUI.color = new Color(1f, 0.5f, 0f);
+                }
+                
+                GUILayout.BeginHorizontal();
+                string playerLabel = "玩家: " + memberName;
+                if (isOwner) playerLabel += " [主机]";
+                if (isLocalPlayer) playerLabel += " [你]";
+                
+                GUILayout.Label(playerLabel, GUILayout.Width(280));
+                GUILayout.EndHorizontal();
+                
+                GUILayout.BeginHorizontal();
+                if (!isLocalPlayer)
+                {
+                    GUILayout.Label("连接状态: " + connectionStatus, GUILayout.Width(200));
+                }
+                else
+                {
+                    GUILayout.Label("连接状态: 本地玩家", GUILayout.Width(200));
+                }
+                GUILayout.EndHorizontal();
+                
+                GUILayout.BeginHorizontal();
+                string steamIdStr = memberId.m_SteamID.ToString();
+                string displayId = steamIdStr.Length > 16 ? steamIdStr.Substring(0, 16) + "..." : steamIdStr;
+                GUILayout.Label("Steam ID: " + displayId, GUILayout.Width(280));
+                GUILayout.EndHorizontal();
+                
+                GUI.color = oldColor;
+                
+                GUILayout.EndVertical();
+                GUILayout.Space(2);
+            }
+            
+            GUILayout.EndScrollView();
+            GUILayout.EndVertical();
+        }
+        
+        private void DrawLobbyBrowserEnhanced()
+        {
+            GUILayout.BeginVertical(GUI.skin.box);
+            GUILayout.Label("可用大厅 (" + availableLobbies.Count + ")", GUI.skin.box);
+            
+            if (GUILayout.Button("刷新列表", GUILayout.Height(25)))
+            {
+                if (EscapeFromDuckovCoopMod.Net.Steam.SteamNetworkingSocketsManager.Instance != null)
+                {
+                    EscapeFromDuckovCoopMod.Net.Steam.SteamNetworkingSocketsManager.Instance.RequestLobbyList();
+                }
+            }
+            
+            lobbyListScrollPos = GUILayout.BeginScrollView(lobbyListScrollPos, GUILayout.Height(250));
+            
+            foreach (var lobby in availableLobbies)
+            {
+                GUILayout.BeginVertical(GUI.skin.box);
+                
+                Color oldColor = GUI.color;
+                if (!lobby.IsCompatibleMod)
+                {
+                    GUI.color = Color.red;
+                }
+                else
+                {
+                    GUI.color = Color.green;
+                }
+                
+                GUILayout.BeginHorizontal();
+                
+                GUILayout.BeginVertical();
+                GUILayout.Label(lobby.LobbyName + " " + (lobby.HasPassword ? "🔒" : ""));
+                GUILayout.Label("主机: " + lobby.OwnerName);
+                GUILayout.Label("玩家: " + lobby.CurrentPlayers + "/" + lobby.MaxPlayers + 
+                               " | " + (lobby.IsCompatibleMod ? "[兼容]" : "[不兼容]"));
+                GUILayout.EndVertical();
+                
+                GUI.color = oldColor;
+                
+                if (lobby.IsCompatibleMod && GUILayout.Button("加入", GUILayout.Width(80), GUILayout.Height(60)))
+                {
+                    steamLobbyId = lobby.LobbyId.m_SteamID.ToString();
+                    if (lobby.HasPassword && string.IsNullOrEmpty(lobbyPassword))
+                    {
+                        status = "此大厅需要密码，请在下方输入密码后再加入";
+                    }
+                    else
+                    {
+                        JoinSteamLobby(lobby.LobbyId, lobby.HasPassword ? lobbyPassword : "");
+                        showLobbyBrowser = false;
+                    }
+                }
+                
+                GUILayout.EndHorizontal();
+                GUILayout.EndVertical();
+                GUILayout.Space(3);
+            }
+            
+            GUILayout.EndScrollView();
+            GUILayout.EndVertical();
+        }
+        
+        private void JoinSteamLobby(CSteamID lobbyId, string password)
+        {
+            Debug.Log("[UI] ==================== JoinSteamLobby ====================");
+            Debug.Log("[UI] 大厅ID: " + lobbyId);
+            Debug.Log("[UI] 密码: " + (string.IsNullOrEmpty(password) ? "无" : "有"));
+            Debug.Log("[UI] 使用虚拟网络P2P: " + ((ModUI)this).IsUsingVirtualNetworkP2P());
+            
+            if (((ModUI)this).IsUsingVirtualNetworkP2P())
+            {
+                Debug.Log("[UI] 使用虚拟网络P2P模式加入大厅");
+                var steamLobbyMgr = EscapeFromDuckovCoopMod.Net.Steam.SteamLobbyManager.Instance;
+                if (steamLobbyMgr != null)
+                {
+                    Debug.Log("[UI] 调用SteamLobbyManager.JoinLobby");
+                    steamLobbyMgr.JoinLobby(lobbyId, password);
+                    status = "正在加入Steam大厅（虚拟网络）...";
+                }
+                else
+                {
+                    Debug.LogError("[UI] SteamLobbyManager未初始化");
+                    status = "Steam Lobby服务未初始化";
+                }
+            }
+            else if (HybridService != null)
+            {
+                Debug.Log("[UI] 使用混合P2P模式加入大厅");
+                HybridService.Initialize(currentNetworkMode);
+                var steamNet = EscapeFromDuckovCoopMod.Net.Steam.SteamNetworkingSocketsManager.Instance;
+                if (steamNet != null)
+                {
+                    Debug.Log("[UI] 调用SteamNetworkingSocketsManager.JoinLobby");
+                    steamNet.JoinLobby(lobbyId, password);
+                    status = "正在连接到Steam大厅（混合）...";
+                }
+                else
+                {
+                    Debug.LogError("[UI] SteamNetworkingSocketsManager未初始化");
+                    status = "Steam网络服务未初始化";
+                }
+            }
+            else
+            {
+                Debug.LogError("[UI] 网络服务未初始化");
+                status = "网络服务未初始化";
+            }
+        }
+        
+        private void DrawVirtualNetworkPlayerList()
+        {
+            var steamLobbyMgr = EscapeFromDuckovCoopMod.Net.Steam.SteamLobbyManager.Instance;
+            if (steamLobbyMgr == null || !steamLobbyMgr.IsInLobby) return;
+            
+            GUILayout.BeginVertical(GUI.skin.box);
+            
+            Steamworks.CSteamID currentLobby = steamLobbyMgr.GetCurrentLobbyId();
+            int memberCount = Steamworks.SteamMatchmaking.GetNumLobbyMembers(currentLobby);
+            
+            int connectedCount = 0;
+            if (NetService.Instance != null && NetService.Instance.IsServer)
+            {
+                connectedCount = NetService.Instance.playerStatuses.Count;
+            }
+            else if (NetService.Instance != null && !NetService.Instance.IsServer && NetService.Instance.connectedPeer != null)
+            {
+                connectedCount = 1;
+            }
+            
+            GUILayout.Label("在线玩家列表", GUI.skin.box);
+            GUILayout.Label("大厅成员: " + memberCount + " | 网络已连接: " + connectedCount);
+            GUILayout.Space(3);
+            
+            playerListScrollPos = GUILayout.BeginScrollView(playerListScrollPos, GUILayout.Height(200));
+            
+            for (int i = 0; i < memberCount; i++)
+            {
+                Steamworks.CSteamID memberId = Steamworks.SteamMatchmaking.GetLobbyMemberByIndex(currentLobby, i);
+                string memberName = Steamworks.SteamFriends.GetFriendPersonaName(memberId);
+                bool isOwner = memberId == Steamworks.SteamMatchmaking.GetLobbyOwner(currentLobby);
+                Steamworks.CSteamID localSteamId = Steamworks.SteamUser.GetSteamID();
+                bool isLocalPlayer = memberId == localSteamId;
+                
+                string connectionStatus = "等待连接";
+                if (isLocalPlayer)
+                {
+                    connectionStatus = "本地玩家";
+                }
+                else if (NetService.Instance != null && NetService.Instance.networkStarted)
+                {
+                    connectionStatus = "已连接";
+                }
+                
+                GUILayout.BeginVertical(GUI.skin.box);
+                
+                Color oldColor = GUI.color;
+                if (isOwner)
+                {
+                    GUI.color = Color.yellow;
+                }
+                else if (isLocalPlayer)
+                {
+                    GUI.color = Color.cyan;
+                }
+                else
+                {
+                    GUI.color = Color.green;
+                }
+                
+                GUILayout.BeginHorizontal();
+                string playerLabel = memberName;
+                if (isOwner) playerLabel += " [房主]";
+                if (isLocalPlayer) playerLabel += " [我]";
+                GUILayout.Label(playerLabel, GUILayout.Width(250));
+                GUILayout.FlexibleSpace();
+                GUILayout.Label(connectionStatus, GUILayout.Width(100));
+                GUILayout.EndHorizontal();
+                
+                GUI.color = oldColor;
+                GUILayout.EndVertical();
+                GUILayout.Space(3);
+            }
+            
+            GUILayout.EndScrollView();
+            GUILayout.EndVertical();
+        }
+        
+        private GUIStyle CreateBoxStyle(Color color)
+        {
+            GUIStyle style = new GUIStyle(GUI.skin.box);
+            Texture2D tex = new Texture2D(1, 1);
+            tex.SetPixel(0, 0, color);
+            tex.Apply();
+            style.normal.background = tex;
+            return style;
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Main/Weapon_/GrenadeM.cs
+++ b/EscapeFromDuckovCoopMod/Main/Weapon_/GrenadeM.cs
@@ -100,7 +100,19 @@ namespace EscapeFromDuckovCoopMod
             writer.Put(delayTime);
             writer.Put(isLandmine);
             writer.Put(landmineRange);
-            connectedPeer.Send(writer, DeliveryMethod.ReliableOrdered);
+            
+            if (connectedPeer != null)
+            {
+                connectedPeer.Send(writer, DeliveryMethod.ReliableOrdered);
+            }
+            else
+            {
+                var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                if (hybrid != null && hybrid.IsConnected)
+                {
+                    hybrid.SendData(writer.Data, writer.Length, DeliveryMethod.ReliableOrdered);
+                }
+            }
         }
 
         // 客户端：生成视觉手雷
@@ -160,7 +172,7 @@ namespace EscapeFromDuckovCoopMod
             var prefab = await EscapeFromDuckovCoopMod.COOPManager.GetGrenadePrefabByItemIdAsync(typeId);
             if (!prefab)
             {
-                UnityEngine.Debug.LogError($"[CLIENT] grenade prefab exact resolve failed: typeId={typeId}");
+                UnityEngine.Debug.LogError("[CLIENT] grenade prefab exact resolve failed: typeId=" + typeId);
                 return;
             }
 
@@ -187,7 +199,7 @@ namespace EscapeFromDuckovCoopMod
             var prefab = await EscapeFromDuckovCoopMod.COOPManager.GetGrenadePrefabByItemIdAsync(p.typeId);
             if (!prefab)
             {
-                UnityEngine.Debug.LogError($"[CLIENT] grenade prefab exact resolve failed: typeId={p.typeId}");
+                UnityEngine.Debug.LogError("[CLIENT] grenade prefab exact resolve failed: typeId=" + p.typeId);
                 return;
             }
 
@@ -226,7 +238,7 @@ namespace EscapeFromDuckovCoopMod
                 // 过期就丢弃
                 if (Time.unscaledTime > p.expireAt)
                 {
-                    UnityEngine.Debug.LogError($"[CLIENT] grenade prefab resolve timeout: typeId={p.typeId}");
+                    UnityEngine.Debug.LogError("[CLIENT] grenade prefab resolve timeout: typeId=" + p.typeId);
                     pending.RemoveAt(i);
                     continue;
                 }

--- a/EscapeFromDuckovCoopMod/Main/Weather_and_Time/Weather.cs
+++ b/EscapeFromDuckovCoopMod/Main/Weather_and_Time/Weather.cs
@@ -137,18 +137,45 @@ namespace EscapeFromDuckovCoopMod
             w.Put(COOPManager.destructible._deadDestructibleIds.Count);
             foreach (var id in COOPManager.destructible._deadDestructibleIds) w.Put(id);
 
-            if (target != null) target.Send(w, DeliveryMethod.ReliableOrdered);
-            else netManager.SendToAll(w, DeliveryMethod.ReliableOrdered);
+            if (target != null)
+            {
+                target.Send(w, DeliveryMethod.ReliableOrdered);
+            }
+            else if (netManager != null)
+            {
+                netManager.SendToAll(w, DeliveryMethod.ReliableOrdered);
+            }
+            else
+            {
+                var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                if (hybrid != null && hybrid.IsConnected)
+                {
+                    hybrid.BroadcastData(w.Data, w.Length, DeliveryMethod.ReliableOrdered);
+                }
+            }
         }
 
 
         // ========== 环境同步：客户端请求 ==========
         public void Client_RequestEnvSync()
         {
-            if (IsServer || connectedPeer == null) return;
+            if (IsServer) return;
+            
             var w = new NetDataWriter();
             w.Put((byte)Op.ENV_SYNC_REQUEST);
-            connectedPeer.Send(w, DeliveryMethod.Sequenced);
+            
+            if (connectedPeer != null)
+            {
+                connectedPeer.Send(w, DeliveryMethod.Sequenced);
+            }
+            else
+            {
+                var hybrid = EscapeFromDuckovCoopMod.Net.Steam.HybridNetworkService.Instance;
+                if (hybrid != null && hybrid.IsConnected)
+                {
+                    hybrid.SendData(w.Data, w.Length, DeliveryMethod.Sequenced);
+                }
+            }
         }
 
         // ========== 环境同步：客户端应用 ==========

--- a/EscapeFromDuckovCoopMod/Net/Steam/HybridNetworkService.cs
+++ b/EscapeFromDuckovCoopMod/Net/Steam/HybridNetworkService.cs
@@ -1,0 +1,499 @@
+using Steamworks;
+using LiteNetLib;
+using LiteNetLib.Utils;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+
+namespace EscapeFromDuckovCoopMod.Net.Steam
+{
+    public enum NetworkMode
+    {
+        LAN,
+        SteamP2P
+    }
+
+    public class HybridNetworkService : MonoBehaviour
+    {
+        public static HybridNetworkService Instance { get; private set; }
+
+        private NetworkMode currentMode = NetworkMode.LAN;
+        private SteamNetworkTransport steamTransport;
+        private NetService lanService;
+
+        private Dictionary<string, object> peerMap = new Dictionary<string, object>();
+        private Dictionary<string, NetPeer> fakePeerCache = new Dictionary<string, NetPeer>();
+
+        public NetworkMode CurrentMode => currentMode;
+        public bool IsServer { get; private set; }
+        public bool IsConnected { get; private set; }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+        }
+
+        public void Initialize(NetworkMode mode)
+        {
+            currentMode = mode;
+            lanService = NetService.Instance;
+
+            if (mode == NetworkMode.SteamP2P)
+            {
+                if (steamTransport == null)
+                {
+                    steamTransport = SteamNetworkTransport.Instance;
+                    if (steamTransport == null)
+                    {
+                        Debug.LogError("[HybridNetwork] 未找到SteamNetworkTransport实例");
+                        return;
+                    }
+                }
+                
+                steamTransport.OnPeerConnectedEvent += HandleSteamPeerConnected;
+                steamTransport.OnPeerDisconnectedEvent += HandleSteamPeerDisconnected;
+                steamTransport.OnNetworkReceiveEvent += HandleSteamDataReceived;
+
+                Debug.Log("[HybridNetwork] 混合网络服务初始化为Steam P2P模式");
+            }
+            else
+            {
+                Debug.Log("[HybridNetwork] 混合网络服务初始化为LAN模式");
+            }
+        }
+
+        public void StartServer(int maxPlayers = 4)
+        {
+            Debug.Log("==================== 开始启动服务器 ====================");
+            Debug.Log("网络模式: " + currentMode);
+            Debug.Log("最大玩家数: " + maxPlayers);
+            
+            IsServer = true;
+            
+            if (currentMode == NetworkMode.SteamP2P)
+            {
+                Debug.Log("[Steam P2P] 正在启动Steam P2P服务器...");
+                steamTransport.StartAsServer(maxPlayers);
+                Debug.Log("[Steam P2P] Steam P2P传输层已启动");
+                
+                Debug.Log("[Steam P2P] 初始化游戏服务器逻辑...");
+                lanService.InitializeGameLogic(true);
+                Debug.Log("[Steam P2P] 游戏服务器逻辑初始化完成");
+                
+                Debug.Log("[Steam P2P] 大厅ID: " + GetLobbyId());
+            }
+            else
+            {
+                Debug.Log("[LAN] 正在启动LAN服务器...");
+                lanService.StartNetwork(true);
+                Debug.Log("[LAN] LAN服务器已启动，端口: " + lanService.port);
+            }
+
+            IsConnected = true;
+            Debug.Log("服务器启动完成！IsServer=" + IsServer + ", IsConnected=" + IsConnected);
+            Debug.Log("==================== 服务器启动完成 ====================");
+        }
+        
+        public void StartClient()
+        {
+            Debug.Log("==================== 开始启动客户端 ====================");
+            Debug.Log("网络模式: " + currentMode);
+            
+            IsServer = false;
+            
+            if (currentMode == NetworkMode.SteamP2P)
+            {
+                Debug.Log("[Steam P2P] 正在启动Steam P2P客户端...");
+                Debug.Log("[Steam P2P] 初始化游戏客户端逻辑...");
+                
+                if (lanService != null)
+                {
+                    lanService.InitializeGameLogic(false);
+                    Debug.Log("[Steam P2P] 游戏客户端逻辑初始化完成");
+                }
+                else
+                {
+                    Debug.LogWarning("[Steam P2P] NetService实例为null，跳过游戏逻辑初始化");
+                }
+                
+                IsConnected = true;
+                Debug.Log("[Steam P2P] Steam P2P客户端已启动，等待与主机建立连接");
+                Debug.Log("[Steam P2P] 当前大厅ID: " + GetLobbyId());
+            }
+            else
+            {
+                Debug.Log("[LAN] 正在启动LAN客户端...");
+                if (lanService != null)
+                {
+                    lanService.StartNetwork(false);
+                    Debug.Log("[LAN] LAN客户端已启动");
+                }
+                else
+                {
+                    Debug.LogError("[LAN] NetService实例为null，无法启动LAN客户端");
+                }
+            }
+            
+            Debug.Log("客户端启动完成！IsServer=" + IsServer + ", IsConnected=" + IsConnected);
+            Debug.Log("==================== 客户端启动完成 ====================");
+        }
+
+        public void ConnectToServer(string address)
+        {
+            IsServer = false;
+
+            if (currentMode == NetworkMode.SteamP2P)
+            {
+                if (ulong.TryParse(address, out ulong lobbyIdNum))
+                {
+                    CSteamID lobbyId = new CSteamID(lobbyIdNum);
+                    steamTransport.ConnectToServer(lobbyId);
+                    IsConnected = true;
+                }
+                else
+                {
+                    Debug.LogError("无效的Steam大厅ID: " + address);
+                }
+            }
+            else
+            {
+                lanService.StartNetwork(false);
+                if (int.TryParse(lanService.manualPort, out int port))
+                {
+                    lanService.netManager.Connect(address, port, "gameKey");
+                }
+            }
+        }
+
+        public void Disconnect()
+        {
+            Debug.Log("==================== 开始断开网络 ====================");
+            Debug.Log("当前模式: " + currentMode);
+            Debug.Log("IsServer: " + IsServer + ", IsConnected: " + IsConnected);
+            
+            if (currentMode == NetworkMode.SteamP2P)
+            {
+                Debug.Log("[Steam P2P] 正在断开Steam P2P连接...");
+                steamTransport.Disconnect();
+                Debug.Log("[Steam P2P] Steam P2P连接已断开");
+            }
+            else
+            {
+                Debug.Log("[LAN] 正在停止LAN网络...");
+                lanService.StopNetwork();
+                Debug.Log("[LAN] LAN网络已停止");
+            }
+
+            IsConnected = false;
+            IsServer = false;
+            peerMap.Clear();
+            
+            Debug.Log("网络断开完成！IsServer=" + IsServer + ", IsConnected=" + IsConnected);
+            Debug.Log("==================== 网络断开完成 ====================");
+        }
+
+        public void SendData(byte[] data, int length, DeliveryMethod method)
+        {
+            if (!IsConnected)
+            {
+                Debug.LogWarning("[HybridNetwork] SendData失败: 未连接");
+                return;
+            }
+
+            if (currentMode == NetworkMode.SteamP2P)
+            {
+                if (IsServer)
+                {
+                    Debug.LogWarning("[HybridNetwork] SendData: 服务器不应该调用SendData，应该使用BroadcastData");
+                    steamTransport.BroadcastToAll(data, length, method);
+                }
+                else
+                {
+                    // 客户端发送给主机
+                    steamTransport.SendToServer(data, length, method);
+                }
+            }
+            else
+            {
+                if (lanService.connectedPeer != null)
+                {
+                    lanService.connectedPeer.Send(data, method);
+                }
+                else if (IsServer)
+                {
+                    foreach (var peer in lanService.netManager.ConnectedPeerList)
+                    {
+                        peer.Send(data, method);
+                    }
+                }
+            }
+        }
+
+        public void BroadcastData(byte[] data, int length, DeliveryMethod method)
+        {
+            if (!IsConnected || !IsServer) return;
+
+            if (currentMode == NetworkMode.SteamP2P)
+            {
+                steamTransport.BroadcastToAll(data, length, method);
+            }
+            else
+            {
+                foreach (var peer in lanService.netManager.ConnectedPeerList)
+                {
+                    peer.Send(data, method);
+                }
+            }
+        }
+
+        public string GetLobbyId()
+        {
+            if (currentMode == NetworkMode.SteamP2P && steamTransport != null)
+            {
+                var lobbyId = SteamNetworkingSocketsManager.Instance.LobbyId;
+                if (lobbyId.IsValid())
+                {
+                    return lobbyId.m_SteamID.ToString();
+                }
+            }
+            return string.Empty;
+        }
+
+        private void HandleSteamPeerConnected(SteamPeerProxy peer)
+        {
+            Debug.Log("Steam对等端连接: " + peer.EndPoint);
+            peerMap[peer.EndPoint] = peer;
+
+            if (lanService != null)
+            {
+                bool isServer = lanService.IsServer;
+                
+                // 服务器端：添加到 playerStatuses
+                if (isServer)
+                {
+                    if (!lanService.playerStatuses.ContainsKey(peer.EndPoint))
+                    {
+                        lanService.playerStatuses[peer.EndPoint] = new PlayerStatus
+                        {
+                            EndPoint = peer.EndPoint,
+                            PlayerName = "SteamPlayer_" + peer.SteamId,
+                            IsInGame = false,
+                            Position = Vector3.zero,
+                            Rotation = Quaternion.identity
+                        };
+                        Debug.Log("[SERVER] 添加P2P客户端到playerStatuses: " + peer.EndPoint);
+                    }
+                }
+                // 客户端：添加到 clientPlayerStatuses
+                else
+                {
+                    if (!lanService.clientPlayerStatuses.ContainsKey(peer.EndPoint))
+                    {
+                        lanService.clientPlayerStatuses[peer.EndPoint] = new PlayerStatus
+                        {
+                            EndPoint = peer.EndPoint,
+                            PlayerName = "SteamPlayer_" + peer.SteamId,
+                            IsInGame = false,
+                            Position = Vector3.zero,
+                            Rotation = Quaternion.identity
+                        };
+                        Debug.Log("[CLIENT] 添加P2P玩家到clientPlayerStatuses: " + peer.EndPoint);
+                    }
+                }
+            }
+        }
+
+        private void HandleSteamPeerDisconnected(SteamPeerProxy peer)
+        {
+            Debug.Log("Steam对等端断开: " + peer.EndPoint);
+            peerMap.Remove(peer.EndPoint);
+
+            if (lanService != null)
+            {
+                bool isServer = lanService.IsServer;
+                
+                if (isServer)
+                {
+                    // 服务器端：从 playerStatuses 和 remoteCharacters 移除
+                    lanService.playerStatuses.Remove(peer.EndPoint);
+                    if (lanService.remoteCharacters.TryGetValue(peer.EndPoint, out var character))
+                    {
+                        if (character != null)
+                        {
+                            Destroy(character);
+                        }
+                        lanService.remoteCharacters.Remove(peer.EndPoint);
+                    }
+                    Debug.Log("[SERVER] 移除P2P客户端: " + peer.EndPoint);
+                }
+                else
+                {
+                    // 客户端：从 clientPlayerStatuses 和 clientRemoteCharacters 移除
+                    lanService.clientPlayerStatuses.Remove(peer.EndPoint);
+                    if (lanService.clientRemoteCharacters.TryGetValue(peer.EndPoint, out var character))
+                    {
+                        if (character != null)
+                        {
+                            Destroy(character);
+                        }
+                        lanService.clientRemoteCharacters.Remove(peer.EndPoint);
+                    }
+                    Debug.Log("[CLIENT] 移除P2P玩家: " + peer.EndPoint);
+                }
+            }
+        }
+
+        private void HandleSteamDataReceived(SteamPeerProxy peer, byte[] data, int length)
+        {
+            if (lanService == null)
+            {
+                Debug.LogWarning("[HybridNetwork] lanService为null，跳过数据处理");
+                return;
+            }
+            
+            if (ModBehaviourF.Instance == null)
+            {
+                return;
+            }
+            
+            try
+            {
+                var readerType = typeof(NetPacketReader);
+                var reader = (NetPacketReader)System.Runtime.Serialization.FormatterServices.GetUninitializedObject(readerType);
+                
+                var dataReaderType = typeof(NetDataReader);
+                var dataField = readerType.GetField("_data", BindingFlags.Instance | BindingFlags.NonPublic);
+                if (dataField == null)
+                {
+                    var baseFields = dataReaderType.GetFields(BindingFlags.Instance | BindingFlags.NonPublic);
+                    foreach (var field in baseFields)
+                    {
+                        if (field.Name.Contains("data") || field.Name.Contains("Data"))
+                        {
+                            dataField = field;
+                            break;
+                        }
+                    }
+                }
+                
+                var positionField = readerType.GetField("_position", BindingFlags.Instance | BindingFlags.NonPublic);
+                if (positionField == null)
+                {
+                    positionField = dataReaderType.GetField("_position", BindingFlags.Instance | BindingFlags.NonPublic);
+                }
+                
+                var dataLengthField = readerType.GetField("_dataSize", BindingFlags.Instance | BindingFlags.NonPublic);
+                if (dataLengthField == null)
+                {
+                    dataLengthField = dataReaderType.GetField("_dataSize", BindingFlags.Instance | BindingFlags.NonPublic);
+                }
+                
+                if (dataField != null)
+                {
+                    dataField.SetValue(reader, data);
+                }
+                
+                if (positionField != null)
+                {
+                    positionField.SetValue(reader, 0);
+                }
+                
+                if (dataLengthField != null)
+                {
+                    dataLengthField.SetValue(reader, length);
+                }
+                
+                NetPeer fakePeer = CreateFakeNetPeer(peer.EndPoint);
+                if (fakePeer == null || fakePeer.EndPoint == null)
+                {
+                    Debug.LogError("[HybridNetwork] 无法为EndPoint创建fakePeer: " + peer.EndPoint);
+                    return;
+                }
+                ModBehaviourF.Instance.OnNetworkReceive(fakePeer, reader, 0, DeliveryMethod.ReliableOrdered);
+            }
+            catch (System.Exception ex)
+            {
+                Debug.LogError("[HybridNetwork] Steam数据处理错误: " + ex.Message);
+                Debug.LogError("[HybridNetwork] 堆栈: " + ex.StackTrace);
+            }
+        }
+        
+        private NetPeer CreateFakeNetPeer(string endPoint)
+        {
+            if (fakePeerCache.TryGetValue(endPoint, out var cached))
+            {
+                return cached;
+            }
+            
+            var netPeerType = typeof(NetPeer);
+            var fakePeer = (NetPeer)System.Runtime.Serialization.FormatterServices.GetUninitializedObject(netPeerType);
+            
+            // 尝试多个可能的字段名
+            var endPointField = netPeerType.GetField("_remoteEndPoint", BindingFlags.Instance | BindingFlags.NonPublic);
+            if (endPointField == null)
+            {
+                endPointField = netPeerType.GetField("_endPoint", BindingFlags.Instance | BindingFlags.NonPublic);
+            }
+            if (endPointField == null)
+            {
+                endPointField = netPeerType.GetField("EndPoint", BindingFlags.Instance | BindingFlags.Public);
+            }
+            
+            if (endPointField == null)
+            {
+                // 列出所有字段用于调试
+                var allFields = netPeerType.GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+                Debug.LogError("[HybridNetwork] 无法找到NetPeer的EndPoint字段。所有字段: " + string.Join(", ", System.Linq.Enumerable.Select(allFields, f => f.Name)));
+            }
+            
+            if (endPointField != null)
+            {
+                try
+                {
+                    int port = endPoint.GetHashCode() & 0xFFFF;
+                    if (port < 1024) port += 10000;
+                    var ipEndPoint = new System.Net.IPEndPoint(System.Net.IPAddress.Parse("127.0.0.1"), port);
+                    endPointField.SetValue(fakePeer, ipEndPoint);
+                }
+                catch
+                {
+                    var ipEndPoint = new System.Net.IPEndPoint(System.Net.IPAddress.Parse("127.0.0.1"), 9050);
+                    endPointField.SetValue(fakePeer, ipEndPoint);
+                }
+            }
+            
+            var remoteIdField = netPeerType.GetField("_id", BindingFlags.Instance | BindingFlags.NonPublic);
+            if (remoteIdField != null)
+            {
+                remoteIdField.SetValue(fakePeer, endPoint.GetHashCode());
+            }
+            
+            // 验证EndPoint是否设置成功
+            if (fakePeer.EndPoint == null)
+            {
+                Debug.LogError("[HybridNetwork] CreateFakeNetPeer失败：无法设置EndPoint字段，反射可能失败");
+                return null;
+            }
+            
+            fakePeerCache[endPoint] = fakePeer;
+            return fakePeer;
+        }
+
+        private void OnDestroy()
+        {
+            if (steamTransport != null)
+            {
+                steamTransport.OnPeerConnectedEvent -= HandleSteamPeerConnected;
+                steamTransport.OnPeerDisconnectedEvent -= HandleSteamPeerDisconnected;
+                steamTransport.OnNetworkReceiveEvent -= HandleSteamDataReceived;
+            }
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/Steam/SteamEndPointMapper.cs
+++ b/EscapeFromDuckovCoopMod/Net/Steam/SteamEndPointMapper.cs
@@ -1,0 +1,211 @@
+// Escape-From-Duckov-Coop-Mod-Preview
+// Copyright (C) 2025  Mr.sans and InitLoader's team
+
+using Steamworks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using UnityEngine;
+
+namespace EscapeFromDuckovCoopMod.Net.Steam
+{
+    public class SteamEndPointMapper : MonoBehaviour
+    {
+        public static SteamEndPointMapper Instance { get; private set; }
+        
+        private Dictionary<CSteamID, IPEndPoint> _steamToEndPoint = new Dictionary<CSteamID, IPEndPoint>();
+        private Dictionary<IPEndPoint, CSteamID> _endPointToSteam = new Dictionary<IPEndPoint, CSteamID>();
+        private int _virtualIpCounter = 1;
+        
+        private const byte VirtualIpPrefix1 = 10;
+        private const byte VirtualIpPrefix2 = 255;
+        
+        private void Awake()
+        {
+            if (Instance != null)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            Debug.Log("[SteamEndPointMapper] 初始化完成");
+        }
+        
+        public System.Collections.IEnumerator WaitForP2PSessionEstablished(CSteamID remoteSteamID, System.Action<bool> callback, float timeout = 10f)
+        {
+            float elapsed = 0f;
+            
+            Debug.Log("[SteamEndPointMapper] 等待P2P会话建立: " + remoteSteamID);
+            
+            while (elapsed < timeout)
+            {
+                if (SteamManager.Initialized && SteamNetworking.GetP2PSessionState(remoteSteamID, out P2PSessionState_t sessionState))
+                {
+                    if (sessionState.m_bConnectionActive == 1)
+                    {
+                        Debug.Log("[SteamEndPointMapper] P2P会话已建立: " + remoteSteamID);
+                        callback?.Invoke(true);
+                        yield break;
+                    }
+                }
+                
+                yield return new WaitForSeconds(0.5f);
+                elapsed += 0.5f;
+            }
+            
+            Debug.LogWarning("[SteamEndPointMapper] P2P会话建立超时: " + remoteSteamID);
+            callback?.Invoke(false);
+        }
+        
+        public IPEndPoint RegisterSteamID(CSteamID steamID, int port = 27015)
+        {
+            CSteamID mySteamID = SteamUser.GetSteamID();
+            if (steamID == mySteamID)
+            {
+                Debug.Log("[SteamEndPointMapper] 跳过注册本地玩家的SteamID: " + steamID);
+                return null;
+            }
+            
+            if (_steamToEndPoint.TryGetValue(steamID, out IPEndPoint existingEndPoint))
+            {
+                Debug.Log("[SteamEndPointMapper] Steam ID " + steamID + " 已注册为 " + existingEndPoint);
+                return existingEndPoint;
+            }
+            
+            IPEndPoint virtualEndPoint = GenerateVirtualEndPoint(port);
+            _steamToEndPoint[steamID] = virtualEndPoint;
+            _endPointToSteam[virtualEndPoint] = steamID;
+            
+            Debug.Log("[SteamEndPointMapper] ========== 虚拟IP映射 ==========");
+            Debug.Log("[SteamEndPointMapper] SteamID: " + steamID);
+            Debug.Log("[SteamEndPointMapper] 虚拟IP: " + virtualEndPoint.Address + ":" + virtualEndPoint.Port);
+            Debug.Log("[SteamEndPointMapper] 当前映射数量: " + _steamToEndPoint.Count);
+            
+            if (SteamManager.Initialized)
+            {
+                bool accepted = SteamNetworking.AcceptP2PSessionWithUser(steamID);
+                
+                byte[] handshake = System.Text.Encoding.UTF8.GetBytes("HANDSHAKE");
+                for (int i = 0; i < 3; i++)
+                {
+                    SteamNetworking.SendP2PPacket(
+                        steamID, handshake, (uint)handshake.Length,
+                        EP2PSend.k_EP2PSendUnreliableNoDelay, 0
+                    );
+                }
+                
+                bool sent = SteamNetworking.SendP2PPacket(
+                    steamID, handshake, (uint)handshake.Length,
+                    EP2PSend.k_EP2PSendReliable, 0
+                );
+                
+                Debug.Log("[SteamEndPointMapper] NAT穿透握手: " + (sent ? "成功" : "失败"));
+            }
+            
+            return virtualEndPoint;
+        }
+        
+        public bool TryGetSteamID(IPEndPoint endPoint, out CSteamID steamID)
+        {
+            return _endPointToSteam.TryGetValue(endPoint, out steamID);
+        }
+        
+        public bool TryGetEndPoint(CSteamID steamID, out IPEndPoint endPoint)
+        {
+            return _steamToEndPoint.TryGetValue(steamID, out endPoint);
+        }
+        
+        public void UnregisterSteamID(CSteamID steamID)
+        {
+            if (_steamToEndPoint.TryGetValue(steamID, out IPEndPoint endPoint))
+            {
+                _steamToEndPoint.Remove(steamID);
+                _endPointToSteam.Remove(endPoint);
+                Debug.Log("[SteamEndPointMapper] 移除映射: " + steamID + " <-> " + endPoint);
+            }
+        }
+        
+        public void UnregisterEndPoint(IPEndPoint endPoint)
+        {
+            if (_endPointToSteam.TryGetValue(endPoint, out CSteamID steamID))
+            {
+                _endPointToSteam.Remove(endPoint);
+                _steamToEndPoint.Remove(steamID);
+                Debug.Log("[SteamEndPointMapper] 移除映射: " + steamID + " <-> " + endPoint);
+            }
+        }
+        
+        public bool IsVirtualEndPoint(IPEndPoint endPoint)
+        {
+            if (endPoint == null)
+                return false;
+                
+            byte[] addressBytes = endPoint.Address.GetAddressBytes();
+            if (addressBytes.Length == 4)
+            {
+                return addressBytes[0] == VirtualIpPrefix1 && addressBytes[1] == VirtualIpPrefix2;
+            }
+            return false;
+        }
+        
+        public List<CSteamID> GetAllSteamIDs()
+        {
+            return _steamToEndPoint.Keys.ToList();
+        }
+        
+        public List<IPEndPoint> GetAllEndPoints()
+        {
+            return _endPointToSteam.Keys.ToList();
+        }
+        
+        public void ClearAll()
+        {
+            _steamToEndPoint.Clear();
+            _endPointToSteam.Clear();
+            _virtualIpCounter = 1;
+            Debug.Log("[SteamEndPointMapper] 已清空所有映射");
+        }
+        
+        public void OnP2PSessionEstablished(CSteamID remoteSteamID)
+        {
+            if (!_steamToEndPoint.ContainsKey(remoteSteamID))
+            {
+                RegisterSteamID(remoteSteamID);
+            }
+        }
+        
+        public void OnP2PSessionFailed(CSteamID remoteSteamID)
+        {
+            UnregisterSteamID(remoteSteamID);
+        }
+        
+        private IPEndPoint GenerateVirtualEndPoint(int port)
+        {
+            byte byte3 = (byte)(_virtualIpCounter / 256);
+            byte byte4 = (byte)(_virtualIpCounter % 256);
+            _virtualIpCounter++;
+            
+            if (_virtualIpCounter > 65535)
+            {
+                _virtualIpCounter = 1;
+            }
+            
+            IPAddress virtualIP = new IPAddress(new byte[] { VirtualIpPrefix1, VirtualIpPrefix2, byte3, byte4 });
+            return new IPEndPoint(virtualIP, port);
+        }
+        
+        public string GetMappingStats()
+        {
+            return "[SteamEndPointMapper] 当前映射数: " + _steamToEndPoint.Count;
+        }
+        
+        private void OnDestroy()
+        {
+            Debug.Log(GetMappingStats());
+            ClearAll();
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/Steam/SteamLobbyHelper.cs
+++ b/EscapeFromDuckovCoopMod/Net/Steam/SteamLobbyHelper.cs
@@ -1,0 +1,72 @@
+// Escape-From-Duckov-Coop-Mod-Preview
+// Copyright (C) 2025  Mr.sans and InitLoader's team
+
+using Steamworks;
+using System;
+using UnityEngine;
+
+namespace EscapeFromDuckovCoopMod.Net.Steam
+{
+    public static class SteamLobbyHelper
+    {
+        public static void TriggerMultiplayerConnect(CSteamID hostSteamID)
+        {
+            try
+            {
+                Debug.Log("[SteamLobbyHelper] ========== 开始连接流程 ==========");
+                Debug.Log("[SteamLobbyHelper] 主机Steam ID: " + hostSteamID);
+                
+                if (SteamEndPointMapper.Instance == null)
+                {
+                    Debug.LogError("[SteamLobbyHelper] SteamEndPointMapper未初始化");
+                    return;
+                }
+                
+                var virtualEndPoint = SteamEndPointMapper.Instance.RegisterSteamID(hostSteamID, 27015);
+                Debug.Log("[SteamLobbyHelper] 虚拟端点: " + virtualEndPoint);
+                Debug.Log("[SteamLobbyHelper] 等待P2P会话建立...");
+                
+                SteamEndPointMapper.Instance.StartCoroutine(
+                    SteamEndPointMapper.Instance.WaitForP2PSessionEstablished(hostSteamID, (success) =>
+                    {
+                        if (success)
+                        {
+                            Debug.Log("[SteamLobbyHelper] P2P会话已就绪，开始连接");
+                            NetService.Instance.ConnectToHost(virtualEndPoint.Address.ToString(), virtualEndPoint.Port);
+                        }
+                        else
+                        {
+                            Debug.LogError("[SteamLobbyHelper] P2P会话建立失败，无法连接");
+                        }
+                    }, 10f)
+                );
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("[SteamLobbyHelper] 触发连接失败: " + ex);
+                Debug.LogError("[SteamLobbyHelper] 堆栈: " + ex.StackTrace);
+            }
+        }
+        
+        public static void TriggerMultiplayerHost()
+        {
+            Debug.Log("[SteamLobbyHelper] ========== 触发主机启动 ==========");
+            
+            if (NetService.Instance == null)
+            {
+                Debug.LogError("[SteamLobbyHelper] NetService未初始化");
+                return;
+            }
+            
+            if (NetService.Instance.networkStarted && NetService.Instance.IsServer)
+            {
+                Debug.Log("[SteamLobbyHelper] 服务器已启动");
+                return;
+            }
+            
+            Debug.Log("[SteamLobbyHelper] 启动服务器网络");
+            NetService.Instance.StartNetwork(true);
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/Steam/SteamLobbyManager.cs
+++ b/EscapeFromDuckovCoopMod/Net/Steam/SteamLobbyManager.cs
@@ -1,0 +1,188 @@
+// Escape-From-Duckov-Coop-Mod-Preview
+// Copyright (C) 2025  Mr.sans and InitLoader's team
+
+using Steamworks;
+using System;
+using UnityEngine;
+
+namespace EscapeFromDuckovCoopMod.Net.Steam
+{
+    public class SteamLobbyManager : MonoBehaviour
+    {
+        public static SteamLobbyManager Instance { get; private set; }
+        
+        private CSteamID currentLobbyId = CSteamID.Nil;
+        public bool IsInLobby => currentLobbyId.IsValid();
+        
+        private Callback<LobbyCreated_t> _lobbyCreatedCallback;
+        private Callback<LobbyEnter_t> _lobbyEnterCallback;
+        private Callback<GameLobbyJoinRequested_t> _gameLobbyJoinRequestedCallback;
+        
+        public event System.Action<CSteamID> OnLobbyCreatedEvent;
+        public event System.Action<CSteamID> OnLobbyJoinedEvent;
+        
+        private void Awake()
+        {
+            if (Instance != null)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            InitializeCallbacks();
+        }
+        
+        private void InitializeCallbacks()
+        {
+            if (!SteamManager.Initialized)
+            {
+                Debug.LogError("[SteamLobbyManager] Steam未初始化");
+                return;
+            }
+            
+            _lobbyCreatedCallback = Callback<LobbyCreated_t>.Create(OnLobbyCreated);
+            _lobbyEnterCallback = Callback<LobbyEnter_t>.Create(OnLobbyEnter);
+            _gameLobbyJoinRequestedCallback = Callback<GameLobbyJoinRequested_t>.Create(OnGameLobbyJoinRequested);
+            
+            Debug.Log("[SteamLobbyManager] 回调已初始化");
+        }
+        
+        public void CreateLobby(string lobbyName, string password, int maxMembers, ELobbyType lobbyType)
+        {
+            if (!SteamManager.Initialized)
+            {
+                Debug.LogError("[SteamLobbyManager] Steam未初始化，无法创建大厅");
+                return;
+            }
+            
+            Debug.Log("[SteamLobbyManager] 创建大厅: " + lobbyName + " (类型: " + lobbyType + ", 最大人数: " + maxMembers + ")");
+            SteamMatchmaking.CreateLobby(lobbyType, maxMembers);
+        }
+        
+        public void JoinLobby(CSteamID lobbyId, string password = "")
+        {
+            if (!SteamManager.Initialized)
+            {
+                Debug.LogError("[SteamLobbyManager] Steam未初始化，无法加入大厅");
+                return;
+            }
+            
+            Debug.Log("[SteamLobbyManager] 加入大厅: " + lobbyId);
+            SteamMatchmaking.JoinLobby(lobbyId);
+        }
+        
+        public void LeaveLobby()
+        {
+            if (!IsInLobby)
+            {
+                Debug.LogWarning("[SteamLobbyManager] 未在大厅中");
+                return;
+            }
+            
+            Debug.Log("[SteamLobbyManager] 离开大厅: " + currentLobbyId);
+            SteamMatchmaking.LeaveLobby(currentLobbyId);
+            currentLobbyId = CSteamID.Nil;
+        }
+        
+        public CSteamID GetLobbyOwner()
+        {
+            if (!IsInLobby)
+                return CSteamID.Nil;
+            return SteamMatchmaking.GetLobbyOwner(currentLobbyId);
+        }
+        
+        public CSteamID GetCurrentLobbyId()
+        {
+            return currentLobbyId;
+        }
+        
+        public void InviteFriend()
+        {
+            if (!IsInLobby)
+            {
+                Debug.LogWarning("[SteamLobbyManager] 未在大厅中，无法邀请好友");
+                return;
+            }
+            
+            if (SteamUtils.IsOverlayEnabled())
+            {
+                SteamFriends.ActivateGameOverlayInviteDialog(currentLobbyId);
+                Debug.Log("[SteamLobbyManager] 打开Steam邀请好友界面");
+            }
+            else
+            {
+                Debug.LogWarning("[SteamLobbyManager] Steam覆盖层未启用");
+            }
+        }
+        
+        private void OnLobbyCreated(LobbyCreated_t callback)
+        {
+            if (callback.m_eResult != EResult.k_EResultOK)
+            {
+                Debug.LogError("[SteamLobbyManager] 创建大厅失败: " + callback.m_eResult);
+                return;
+            }
+            
+            currentLobbyId = new CSteamID(callback.m_ulSteamIDLobby);
+            Debug.Log("[SteamLobbyManager] 大厅创建成功: " + currentLobbyId);
+            
+            SteamMatchmaking.SetLobbyData(currentLobbyId, "name", "Duckov Coop");
+            SteamMatchmaking.SetLobbyData(currentLobbyId, "version", "1.0");
+            SteamMatchmaking.SetLobbyData(currentLobbyId, "mod_id", "EscapeFromDuckovCoopMod_v1.0");
+            
+            Debug.Log("[SteamLobbyManager] 大厅主机，准备启动服务器（将在OnLobbyEnter时启动）");
+            
+            OnLobbyCreatedEvent?.Invoke(currentLobbyId);
+        }
+        
+        private void OnLobbyEnter(LobbyEnter_t callback)
+        {
+            currentLobbyId = new CSteamID(callback.m_ulSteamIDLobby);
+            
+            EChatRoomEnterResponse response = (EChatRoomEnterResponse)callback.m_EChatRoomEnterResponse;
+            
+            if (response != EChatRoomEnterResponse.k_EChatRoomEnterResponseSuccess)
+            {
+                Debug.LogError("[SteamLobbyManager] 加入大厅失败: " + response);
+                currentLobbyId = CSteamID.Nil;
+                return;
+            }
+            
+            Debug.Log("[SteamLobbyManager] 成功加入大厅: " + currentLobbyId);
+            
+            CSteamID ownerId = SteamMatchmaking.GetLobbyOwner(currentLobbyId);
+            bool amIOwner = ownerId == SteamUser.GetSteamID();
+            
+            Debug.Log("[SteamLobbyManager] 大厅主机: " + ownerId + " (我是主机: " + amIOwner + ")");
+            
+            OnLobbyJoinedEvent?.Invoke(currentLobbyId);
+            
+            if (!amIOwner)
+            {
+                Debug.Log("[SteamLobbyManager] 触发客户端连接流程");
+                SteamLobbyHelper.TriggerMultiplayerConnect(ownerId);
+            }
+            else
+            {
+                Debug.Log("[SteamLobbyManager] 触发主机启动流程");
+                SteamLobbyHelper.TriggerMultiplayerHost();
+            }
+        }
+        
+        private void OnGameLobbyJoinRequested(GameLobbyJoinRequested_t callback)
+        {
+            Debug.Log("[SteamLobbyManager] 收到大厅邀请: " + callback.m_steamIDLobby);
+            JoinLobby(callback.m_steamIDLobby);
+        }
+        
+        private void OnDestroy()
+        {
+            if (IsInLobby)
+            {
+                LeaveLobby();
+            }
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/Steam/SteamLobbyOptions.cs
+++ b/EscapeFromDuckovCoopMod/Net/Steam/SteamLobbyOptions.cs
@@ -1,0 +1,50 @@
+// Escape-From-Duckov-Coop-Mod-Preview
+// Copyright (C) 2025  Mr.sans and InitLoader's team
+
+using Steamworks;
+
+namespace EscapeFromDuckovCoopMod.Net.Steam
+{
+    public enum SteamLobbyVisibility
+    {
+        FriendsOnly,
+        Public
+    }
+    
+    public class SteamLobbyOptions
+    {
+        public string LobbyName { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+        public int MaxPlayers { get; set; } = 2;
+        public SteamLobbyVisibility Visibility { get; set; } = SteamLobbyVisibility.Public;
+        
+        public static SteamLobbyOptions CreateDefault()
+        {
+            var options = new SteamLobbyOptions
+            {
+                LobbyName = "Duckov Lobby",
+                Password = string.Empty,
+                MaxPlayers = 2,
+                Visibility = SteamLobbyVisibility.Public
+            };
+            
+            if (SteamManager.Initialized)
+            {
+                try
+                {
+                    var personaName = SteamFriends.GetPersonaName();
+                    if (!string.IsNullOrWhiteSpace(personaName))
+                    {
+                        options.LobbyName = personaName + "'s Room";
+                    }
+                }
+                catch
+                {
+                }
+            }
+            
+            return options;
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/Steam/SteamNetworkTransport.cs
+++ b/EscapeFromDuckovCoopMod/Net/Steam/SteamNetworkTransport.cs
@@ -1,0 +1,239 @@
+using Steamworks;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using LiteNetLib;
+
+namespace EscapeFromDuckovCoopMod.Net.Steam
+{
+    public class SteamNetworkTransport : MonoBehaviour
+    {
+        public static SteamNetworkTransport Instance { get; private set; }
+
+        private SteamNetworkingSocketsManager steamNetSockets;
+        private Dictionary<CSteamID, SteamPeerProxy> peerProxies = new Dictionary<CSteamID, SteamPeerProxy>();
+        private SteamPeerProxy serverProxy;
+
+        public event Action<SteamPeerProxy> OnPeerConnectedEvent;
+        public event Action<SteamPeerProxy> OnPeerDisconnectedEvent;
+        public event Action<SteamPeerProxy, byte[], int> OnNetworkReceiveEvent;
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+        }
+
+        public void Initialize()
+        {
+            if (steamNetSockets == null)
+            {
+                steamNetSockets = SteamNetworkingSocketsManager.Instance;
+                if (steamNetSockets == null)
+                {
+                    Debug.LogError("[SteamNetTransport] 未找到SteamNetworkingSocketsManager实例");
+                    return;
+                }
+            }
+
+            steamNetSockets.OnPeerConnected += HandlePeerConnected;
+            steamNetSockets.OnPeerDisconnected += HandlePeerDisconnected;
+            steamNetSockets.OnDataReceived += HandleDataReceived;
+            steamNetSockets.OnLobbyCreated += HandleLobbyCreated;
+            steamNetSockets.OnLobbyJoined += HandleLobbyJoined;
+
+            Debug.Log("[SteamNetTransport] 初始化完成");
+        }
+
+        public void StartAsServer(int maxPlayers = 4)
+        {
+            Debug.Log("[SteamNetTransport] 启动服务器，最大玩家: " + maxPlayers);
+            steamNetSockets.StartServer();
+        }
+
+        public void ConnectToServer(CSteamID lobbyId)
+        {
+            Debug.Log("[SteamNetTransport] 连接到服务器，大厅ID: " + lobbyId);
+        }
+
+        public void Disconnect()
+        {
+            Debug.Log("[SteamNetTransport] 断开连接");
+            steamNetSockets.LeaveLobby();
+            peerProxies.Clear();
+            serverProxy = null;
+        }
+
+        public void SendToServer(byte[] data, int length, DeliveryMethod method)
+        {
+            if (serverProxy == null)
+            {
+                Debug.LogError("[SteamNetTransport] SendToServer失败: serverProxy为null！");
+                Debug.LogError("[SteamNetTransport] 客户端可能未正确设置serverProxy");
+                return;
+            }
+            
+            Debug.Log("[SteamNetTransport] 客户端发送数据到主机");
+            Debug.Log("[SteamNetTransport] 主机SteamID: " + serverProxy.SteamId);
+            Debug.Log("[SteamNetTransport] 数据大小: " + length + " bytes");
+            Debug.Log("[SteamNetTransport] 传输方式: " + method);
+            
+            int sendFlags = ConvertDeliveryMethod(method);
+            bool success = steamNetSockets.SendPacket(serverProxy.SteamId, data, length, sendFlags);
+            
+            if (!success)
+            {
+                Debug.LogError("[SteamNetTransport]  SendToServer失败: SendPacket返回false");
+            }
+            else
+            {
+                Debug.Log("[SteamNetTransport]  SendToServer成功");
+            }
+        }
+
+        public void SendToPeer(SteamPeerProxy peer, byte[] data, int length, DeliveryMethod method)
+        {
+            if (peer != null)
+            {
+                int sendFlags = ConvertDeliveryMethod(method);
+                steamNetSockets.SendPacket(peer.SteamId, data, length, sendFlags);
+            }
+        }
+
+        public void BroadcastToAll(byte[] data, int length, DeliveryMethod method)
+        {
+            int sendFlags = ConvertDeliveryMethod(method);
+            steamNetSockets.BroadcastPacket(data, length, sendFlags);
+        }
+
+        private void HandlePeerConnected(CSteamID steamId)
+        {
+            if (!peerProxies.ContainsKey(steamId))
+            {
+                var proxy = new SteamPeerProxy(steamId);
+                peerProxies[steamId] = proxy;
+                OnPeerConnectedEvent?.Invoke(proxy);
+                Debug.Log("[SteamNetTransport] 对等连接建立: " + steamId);
+            }
+        }
+
+        private void HandlePeerDisconnected(CSteamID steamId)
+        {
+            if (peerProxies.TryGetValue(steamId, out var proxy))
+            {
+                peerProxies.Remove(steamId);
+                OnPeerDisconnectedEvent?.Invoke(proxy);
+                Debug.Log("[SteamNetTransport] 对等连接断开: " + steamId);
+            }
+        }
+
+        private void HandleDataReceived(CSteamID senderId, byte[] data, int length)
+        {
+            if (peerProxies.TryGetValue(senderId, out var proxy))
+            {
+                OnNetworkReceiveEvent?.Invoke(proxy, data, length);
+            }
+            else if (serverProxy != null && serverProxy.SteamId == senderId)
+            {
+                OnNetworkReceiveEvent?.Invoke(serverProxy, data, length);
+            }
+        }
+
+        private void HandleLobbyCreated(CSteamID lobbyId)
+        {
+            Debug.Log("[SteamNetTransport] 作为主机创建大厅: " + lobbyId);
+        }
+
+        private void HandleLobbyJoined(CSteamID lobbyId)
+        {
+            CSteamID ownerId = SteamMatchmaking.GetLobbyOwner(lobbyId);
+            CSteamID mySteamId = SteamUser.GetSteamID();
+            
+            Debug.Log("[SteamNetTransport] ==================== 大厅加入处理 ====================");
+            Debug.Log("[SteamNetTransport] 大厅ID: " + lobbyId);
+            Debug.Log("[SteamNetTransport] 大厅所有者: " + ownerId);
+            Debug.Log("[SteamNetTransport] 我的SteamID: " + mySteamId);
+            
+            if (ownerId != mySteamId)
+            {
+                serverProxy = new SteamPeerProxy(ownerId);
+                Debug.Log("[SteamNetTransport]  设置serverProxy: " + serverProxy.EndPoint);
+                Debug.Log("[SteamNetTransport] 作为客户端，准备连接到主机");
+            }
+            else
+            {
+                Debug.Log("[SteamNetTransport] 我是主机，不需要设置serverProxy");
+            }
+        }
+
+        private int ConvertDeliveryMethod(DeliveryMethod method)
+        {
+            switch (method)
+            {
+                case DeliveryMethod.ReliableOrdered:
+                case DeliveryMethod.ReliableUnordered:
+                case DeliveryMethod.ReliableSequenced:
+                    return Constants.k_nSteamNetworkingSend_Reliable;
+                
+                case DeliveryMethod.Sequenced:
+                    return Constants.k_nSteamNetworkingSend_Reliable | Constants.k_nSteamNetworkingSend_NoNagle;
+                
+                case DeliveryMethod.Unreliable:
+                default:
+                    return Constants.k_nSteamNetworkingSend_Unreliable;
+            }
+        }
+
+        public bool IsServer => steamNetSockets != null && steamNetSockets.IsServer;
+        public bool IsConnected => steamNetSockets != null && steamNetSockets.LobbyId.IsValid();
+        public IReadOnlyDictionary<CSteamID, SteamPeerProxy> Peers => peerProxies;
+        public SteamPeerProxy ServerPeer => serverProxy;
+
+        private void OnDestroy()
+        {
+            if (steamNetSockets != null)
+            {
+                steamNetSockets.OnPeerConnected -= HandlePeerConnected;
+                steamNetSockets.OnPeerDisconnected -= HandlePeerDisconnected;
+                steamNetSockets.OnDataReceived -= HandleDataReceived;
+                steamNetSockets.OnLobbyCreated -= HandleLobbyCreated;
+                steamNetSockets.OnLobbyJoined -= HandleLobbyJoined;
+            }
+        }
+    }
+
+    public class SteamPeerProxy
+    {
+        public CSteamID SteamId { get; private set; }
+        public string EndPoint { get; private set; }
+        
+        public SteamPeerProxy(CSteamID steamId)
+        {
+            SteamId = steamId;
+            EndPoint = steamId.ToString();
+        }
+
+        public override string ToString()
+        {
+            return EndPoint;
+        }
+
+        public override int GetHashCode()
+        {
+            return SteamId.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is SteamPeerProxy other)
+            {
+                return SteamId == other.SteamId;
+            }
+            return false;
+        }
+    }
+}

--- a/EscapeFromDuckovCoopMod/Net/Steam/SteamNetworkingSocketsManager.cs
+++ b/EscapeFromDuckovCoopMod/Net/Steam/SteamNetworkingSocketsManager.cs
@@ -1,0 +1,833 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Steamworks;
+
+namespace EscapeFromDuckovCoopMod.Net.Steam
+{
+    public class SteamNetworkingSocketsManager : MonoBehaviour
+    {
+        private static SteamNetworkingSocketsManager instance;
+        public static SteamNetworkingSocketsManager Instance => instance;
+
+        // 回调
+        public event Action<CSteamID, byte[], int> OnDataReceived;
+        public event Action<CSteamID> OnPeerConnected;
+        public event Action<CSteamID> OnPeerDisconnected;
+        
+        // Steam大厅相关
+        public event Action<CSteamID> OnLobbyCreated;
+        public event Action<CSteamID> OnLobbyJoined;
+        public event Action OnLobbyLeft;
+        public event Action<List<LobbyInfo>> OnLobbyListReceived;
+        
+        // 网络状态
+        private bool isInitialized = false;
+        private bool isServer = false;
+        
+        // 大厅信息
+        private CSteamID currentLobbyId = CSteamID.Nil;
+        private string currentLobbyPassword = "";
+        private string currentLobbyName = "";
+        
+        // 连接管理
+        private HSteamListenSocket listenSocket = HSteamListenSocket.Invalid;
+        public Dictionary<CSteamID, HSteamNetConnection> peerConnections = new Dictionary<CSteamID, HSteamNetConnection>();
+        private Dictionary<HSteamNetConnection, CSteamID> connectionToPeer = new Dictionary<HSteamNetConnection, CSteamID>();
+        private Dictionary<CSteamID, PingInfo> peerPings = new Dictionary<CSteamID, PingInfo>();
+        
+        private class PingInfo
+        {
+            public int CurrentPing = 0;
+            public long LastPingSentTime = 0;
+            public long LastPingReceivedTime = 0;
+        }
+        
+        // Steam Callbacks
+        private Callback<SteamNetConnectionStatusChangedCallback_t> connectionStatusCallback;
+        private Callback<LobbyCreated_t> lobbyCreatedCallback;
+        private Callback<LobbyEnter_t> lobbyEnterCallback;
+        private Callback<LobbyChatUpdate_t> lobbyChatUpdateCallback;
+        private Callback<LobbyMatchList_t> lobbyMatchListCallback;
+        private Callback<GameLobbyJoinRequested_t> gameLobbyJoinRequestedCallback;
+        
+        // 常量
+        private const string LOBBY_PASSWORD_KEY = "password";
+        private const string LOBBY_MOD_ID_KEY = "mod_id";
+        private const string LOBBY_NAME_KEY = "name";
+        private const string MOD_IDENTIFIER = "EscapeFromDuckovCoopMod_v1.0";
+        private const int MAX_MESSAGE_SIZE = 512 * 1024; // 512KB
+        private const int VIRTUAL_PORT = 27015;
+        
+        // 消息缓冲区
+        private IntPtr[] messageBuffers = new IntPtr[256];
+        
+        public bool IsInitialized => isInitialized;
+        public bool IsServer => isServer;
+        public CSteamID LobbyId => currentLobbyId;
+        public int ConnectedPeerCount => peerConnections.Count;
+        
+        public int GetPeerPing(CSteamID peerId)
+        {
+            if (peerPings.TryGetValue(peerId, out PingInfo pingInfo))
+            {
+                return pingInfo.CurrentPing;
+            }
+            return -1;
+        }
+
+        public bool IsP2PConnected(CSteamID peerId)
+        {
+            return peerConnections.ContainsKey(peerId);
+        }
+
+        public string GetConnectionStatus(CSteamID peerId)
+        {
+            if (!currentLobbyId.IsValid())
+            {
+                return "未在大厅";
+            }
+
+            if (peerId == SteamUser.GetSteamID())
+            {
+                return "本地玩家";
+            }
+
+            if (peerConnections.ContainsKey(peerId))
+            {
+                if (peerPings.TryGetValue(peerId, out PingInfo pingInfo))
+                {
+                    return "已连接 (" + pingInfo.CurrentPing + "ms)";
+                }
+                return "已连接";
+            }
+
+            return "未建立P2P";
+        }
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private float pingUpdateTimer = 0f;
+        private const float PING_UPDATE_INTERVAL = 1.0f;
+
+        private void SendPingPackets()
+        {
+            long currentTime = System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerMillisecond;
+            
+            foreach (var kvp in peerConnections)
+            {
+                CSteamID peerId = kvp.Key;
+                HSteamNetConnection conn = kvp.Value;
+                
+                if (!peerPings.ContainsKey(peerId))
+                {
+                    peerPings[peerId] = new PingInfo();
+                }
+                
+                byte[] pingData = System.BitConverter.GetBytes(currentTime);
+                byte[] packet = new byte[pingData.Length + 1];
+                packet[0] = 255;
+                System.Array.Copy(pingData, 0, packet, 1, pingData.Length);
+                
+                System.IntPtr dataPtr = System.Runtime.InteropServices.Marshal.AllocHGlobal(packet.Length);
+                System.Runtime.InteropServices.Marshal.Copy(packet, 0, dataPtr, packet.Length);
+                
+                EResult result = SteamNetworkingSockets.SendMessageToConnection(
+                    conn, 
+                    dataPtr, 
+                    (uint)packet.Length, 
+                    Constants.k_nSteamNetworkingSend_Unreliable, 
+                    out long messageNum
+                );
+                
+                System.Runtime.InteropServices.Marshal.FreeHGlobal(dataPtr);
+                
+                if (result == EResult.k_EResultOK)
+                {
+                    peerPings[peerId].LastPingSentTime = currentTime;
+                }
+            }
+        }
+
+        private void ProcessPingPacket(CSteamID senderId, byte[] data)
+        {
+            if (data.Length < 9 || data[0] != 255)
+                return;
+            
+            long sentTime = System.BitConverter.ToInt64(data, 1);
+            long currentTime = System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerMillisecond;
+            int rtt = (int)(currentTime - sentTime);
+            
+            if (!peerPings.ContainsKey(senderId))
+            {
+                peerPings[senderId] = new PingInfo();
+            }
+            
+            peerPings[senderId].CurrentPing = rtt;
+            peerPings[senderId].LastPingReceivedTime = currentTime;
+            
+            byte[] pongData = new byte[data.Length];
+            data.CopyTo(pongData, 0);
+            pongData[0] = 254;
+            
+            if (peerConnections.TryGetValue(senderId, out HSteamNetConnection conn))
+            {
+                System.IntPtr dataPtr = System.Runtime.InteropServices.Marshal.AllocHGlobal(pongData.Length);
+                System.Runtime.InteropServices.Marshal.Copy(pongData, 0, dataPtr, pongData.Length);
+                
+                SteamNetworkingSockets.SendMessageToConnection(
+                    conn, 
+                    dataPtr, 
+                    (uint)pongData.Length, 
+                    Constants.k_nSteamNetworkingSend_Unreliable, 
+                    out long messageNum
+                );
+                
+                System.Runtime.InteropServices.Marshal.FreeHGlobal(dataPtr);
+            }
+        }
+
+        private void ProcessPongPacket(CSteamID senderId, byte[] data)
+        {
+            if (data.Length < 9 || data[0] != 254)
+                return;
+            
+            long sentTime = System.BitConverter.ToInt64(data, 1);
+            long currentTime = System.DateTime.UtcNow.Ticks / System.TimeSpan.TicksPerMillisecond;
+            int rtt = (int)(currentTime - sentTime);
+            
+            if (!peerPings.ContainsKey(senderId))
+            {
+                peerPings[senderId] = new PingInfo();
+            }
+            
+            peerPings[senderId].CurrentPing = rtt;
+            peerPings[senderId].LastPingReceivedTime = currentTime;
+        }
+
+        public void Initialize()
+        {
+            if (isInitialized)
+            {
+                Debug.Log("[SteamNetSockets] 已经初始化");
+                return;
+            }
+
+            if (!SteamManager.Initialized)
+            {
+                Debug.LogError("[SteamNetSockets] Steam未初始化");
+                return;
+            }
+
+            Debug.Log("[SteamNetSockets] ==================== 初始化 ====================");
+            
+            // 初始化回调
+            connectionStatusCallback = Callback<SteamNetConnectionStatusChangedCallback_t>.Create(OnConnectionStatusChanged);
+            lobbyCreatedCallback = Callback<LobbyCreated_t>.Create(OnLobbyCreatedCallback);
+            lobbyEnterCallback = Callback<LobbyEnter_t>.Create(OnLobbyEnterCallback);
+            lobbyChatUpdateCallback = Callback<LobbyChatUpdate_t>.Create(OnLobbyChatUpdateCallback);
+            lobbyMatchListCallback = Callback<LobbyMatchList_t>.Create(OnLobbyMatchListCallback);
+            gameLobbyJoinRequestedCallback = Callback<GameLobbyJoinRequested_t>.Create(OnGameLobbyJoinRequestedCallback);
+
+            isInitialized = true;
+            Debug.Log("[SteamNetSockets] 初始化完成，使用 ISteamNetworkingSockets API");
+        }
+
+        private void Update()
+        {
+            if (!isInitialized) return;
+            
+            // 接收所有连接的消息
+            ReceiveMessages();
+            
+            // 定期发送ping包
+            if (peerConnections.Count > 0)
+            {
+                pingUpdateTimer += Time.deltaTime;
+                if (pingUpdateTimer >= PING_UPDATE_INTERVAL)
+                {
+                    pingUpdateTimer = 0f;
+                    SendPingPackets();
+                }
+            }
+        }
+
+        #region 大厅管理
+
+        public void CreateLobby(int maxPlayers, ELobbyType lobbyType, string lobbyName, string password = "")
+        {
+            if (!isInitialized)
+            {
+                Debug.LogError("[SteamNetSockets] 未初始化");
+                return;
+            }
+            
+            Debug.Log("[SteamNetSockets] ==================== 创建大厅 ====================");
+            Debug.Log("[SteamNetSockets] 类型: " + lobbyType + ", 最大玩家数: " + maxPlayers);
+            Debug.Log("[SteamNetSockets] 名称: " + lobbyName);
+            Debug.Log("[SteamNetSockets] 密码: " + (string.IsNullOrEmpty(password) ? "无" : "有"));
+            
+            currentLobbyName = lobbyName;
+            currentLobbyPassword = password;
+            SteamAPICall_t apiCall = SteamMatchmaking.CreateLobby(lobbyType, maxPlayers);
+            Debug.Log("[SteamNetSockets] Steam API调用ID: " + apiCall.m_SteamAPICall);
+        }
+
+        public void JoinLobby(CSteamID lobbyId, string password = "")
+        {
+            if (!isInitialized)
+            {
+                Debug.LogError("[SteamNetSockets] 未初始化");
+                return;
+            }
+
+            Debug.Log("[SteamNetSockets] ==================== 加入大厅 ====================");
+            Debug.Log("[SteamNetSockets] 大厅ID: " + lobbyId);
+            Debug.Log("[SteamNetSockets] 密码: " + (string.IsNullOrEmpty(password) ? "无" : "有"));
+            
+            currentLobbyPassword = password;
+            SteamMatchmaking.JoinLobby(lobbyId);
+        }
+
+        public void LeaveLobby()
+        {
+            if (!currentLobbyId.IsValid())
+            {
+                Debug.LogWarning("[SteamNetSockets] 不在大厅中");
+                return;
+            }
+
+            Debug.Log("[SteamNetSockets] ==================== 离开大厅 ====================");
+            Debug.Log("[SteamNetSockets] 大厅ID: " + currentLobbyId);
+            
+            // 关闭所有连接
+            CloseAllConnections();
+            
+            // 离开Steam大厅
+            CSteamID oldLobby = currentLobbyId;
+            SteamMatchmaking.LeaveLobby(currentLobbyId);
+            
+            currentLobbyId = CSteamID.Nil;
+            currentLobbyPassword = "";
+            currentLobbyName = "";
+            isServer = false;
+            
+            Debug.Log("[SteamNetSockets] 已离开大厅: " + oldLobby);
+            OnLobbyLeft?.Invoke();
+        }
+
+        public void RequestLobbyList()
+        {
+            if (!isInitialized)
+            {
+                Debug.LogError("[SteamNetSockets] 未初始化");
+                return;
+            }
+
+            Debug.Log("[SteamNetSockets] 请求大厅列表");
+            
+            // 添加过滤器
+            SteamMatchmaking.AddRequestLobbyListDistanceFilter(ELobbyDistanceFilter.k_ELobbyDistanceFilterWorldwide);
+            SteamMatchmaking.AddRequestLobbyListResultCountFilter(50);
+            SteamMatchmaking.AddRequestLobbyListStringFilter(LOBBY_MOD_ID_KEY, MOD_IDENTIFIER, ELobbyComparison.k_ELobbyComparisonEqual);
+            
+            SteamMatchmaking.RequestLobbyList();
+        }
+
+        public void InviteUserToLobby(CSteamID friendId)
+        {
+            if (!isInitialized || !currentLobbyId.IsValid())
+            {
+                Debug.LogError("[SteamNetSockets] 未在大厅中");
+                return;
+            }
+
+            Debug.Log("[SteamNetSockets] 邀请好友: " + friendId + " (" + SteamFriends.GetFriendPersonaName(friendId) + ")");
+            
+            bool success = SteamMatchmaking.InviteUserToLobby(currentLobbyId, friendId);
+            if (success)
+            {
+                Debug.Log("[SteamNetSockets] 邀请已发送");
+            }
+            else
+            {
+                Debug.LogError("[SteamNetSockets] 邀请发送失败");
+            }
+        }
+
+        public string GetLobbyData(string key)
+        {
+            if (!currentLobbyId.IsValid()) return "";
+            return SteamMatchmaking.GetLobbyData(currentLobbyId, key);
+        }
+
+        public void SetLobbyData(string key, string value)
+        {
+            if (!currentLobbyId.IsValid() || !isServer) return;
+            
+            Debug.Log("[SteamNetSockets] 设置大厅数据: " + key + " = " + value);
+            SteamMatchmaking.SetLobbyData(currentLobbyId, key, value);
+        }
+
+        #endregion
+
+        #region 连接管理
+
+        public void StartServer()
+        {
+            if (listenSocket != HSteamListenSocket.Invalid)
+            {
+                Debug.LogWarning("[SteamNetSockets] 服务器已启动");
+                return;
+            }
+
+            Debug.Log("[SteamNetSockets] ==================== 启动服务器 ====================");
+            
+            isServer = true;
+            
+            Debug.Log("[SteamNetSockets] 创建P2P监听套接字，虚拟端口: " + VIRTUAL_PORT);
+            listenSocket = SteamNetworkingSockets.CreateListenSocketP2P(VIRTUAL_PORT, 0, null);
+            
+            if (listenSocket == HSteamListenSocket.Invalid)
+            {
+                Debug.LogError("[SteamNetSockets] 创建P2P监听套接字失败!");
+                return;
+            }
+            
+            Debug.Log("[SteamNetSockets] P2P监听套接字创建成功: " + listenSocket.m_HSteamListenSocket);
+            Debug.Log("[SteamNetSockets] P2P服务器模式，等待客户端连接");
+        }
+
+        public void ConnectToHost(CSteamID hostSteamId)
+        {
+            if (peerConnections.ContainsKey(hostSteamId))
+            {
+                Debug.LogWarning("[SteamNetSockets] 已经连接到主机: " + hostSteamId);
+                Debug.LogWarning("[SteamNetSockets] 连接句柄: " + peerConnections[hostSteamId].m_HSteamNetConnection);
+                return;
+            }
+
+            Debug.Log("[SteamNetSockets] ==================== 连接到主机 ====================");
+            Debug.Log("[SteamNetSockets] 主机SteamID: " + hostSteamId);
+            Debug.Log("[SteamNetSockets] 我的SteamID: " + SteamUser.GetSteamID());
+            Debug.Log("[SteamNetSockets] 虚拟端口: " + VIRTUAL_PORT);
+            Debug.Log("[SteamNetSockets] 当前已有连接数: " + peerConnections.Count);
+            
+            SteamNetworkingIdentity identity = new SteamNetworkingIdentity();
+            identity.SetSteamID(hostSteamId);
+            
+            HSteamNetConnection conn = SteamNetworkingSockets.ConnectP2P(ref identity, VIRTUAL_PORT, 0, null);
+            
+            if (conn == HSteamNetConnection.Invalid)
+            {
+                Debug.LogError("[SteamNetSockets]  ConnectP2P返回无效句柄！");
+                return;
+            }
+            
+            peerConnections[hostSteamId] = conn;
+            connectionToPeer[conn] = hostSteamId;
+            
+            Debug.Log("[SteamNetSockets]  P2P连接已初始化");
+            Debug.Log("[SteamNetSockets] 连接句柄: " + conn.m_HSteamNetConnection);
+            Debug.Log("[SteamNetSockets] 目标SteamID: " + hostSteamId);
+            Debug.Log("[SteamNetSockets] 已存储到peerConnections，当前总数: " + peerConnections.Count);
+        }
+
+        private void CloseAllConnections()
+        {
+            Debug.Log("[SteamNetSockets] 关闭所有连接，当前连接数: " + peerConnections.Count);
+            
+            foreach (var conn in peerConnections.Values)
+            {
+                SteamNetworkingSockets.CloseConnection(conn, 0, "Leaving lobby", false);
+            }
+            
+            peerConnections.Clear();
+            connectionToPeer.Clear();
+            
+            if (listenSocket != HSteamListenSocket.Invalid)
+            {
+                SteamNetworkingSockets.CloseListenSocket(listenSocket);
+                listenSocket = HSteamListenSocket.Invalid;
+            }
+            
+            Debug.Log("[SteamNetSockets] 所有连接已关闭");
+        }
+
+        #endregion
+
+        #region 数据传输
+
+        public bool SendPacket(CSteamID target, byte[] data, int length, int sendFlags = Constants.k_nSteamNetworkingSend_Reliable)
+        {
+            if (!peerConnections.TryGetValue(target, out HSteamNetConnection conn))
+            {
+                Debug.LogError("[P2P发包] 未找到到目标的连接！");
+                Debug.LogError("[P2P发包] 目标SteamID: " + target);
+                Debug.LogError("[P2P发包] IsServer: " + isServer);
+                Debug.LogError("[P2P发包] 当前连接数: " + peerConnections.Count);
+                
+                // 打印所有已连接的peers
+                int idx = 0;
+                foreach (var kvp in peerConnections)
+                {
+                    Debug.LogError("[P2P发包] [" + idx + "] 已连接SteamID: " + kvp.Key + " → 连接句柄: " + kvp.Value.m_HSteamNetConnection);
+                    idx++;
+                }
+                
+                return false;
+            }
+
+            if (length > MAX_MESSAGE_SIZE)
+            {
+                Debug.LogError("[P2P发包] 数据包过大: " + length + " bytes");
+                return false;
+            }
+
+            // Debug.Log("[P2P发包] 发送数据包 -> 目标: " + target + ", 大小: " + length + " bytes");
+            
+            System.IntPtr dataPtr = System.Runtime.InteropServices.Marshal.AllocHGlobal(length);
+            System.Runtime.InteropServices.Marshal.Copy(data, 0, dataPtr, length);
+            
+            EResult result = SteamNetworkingSockets.SendMessageToConnection(conn, dataPtr, (uint)length, sendFlags, out long messageNumber);
+            
+            System.Runtime.InteropServices.Marshal.FreeHGlobal(dataPtr);
+            
+            if (result != EResult.k_EResultOK)
+            {
+                Debug.LogError("[P2P发包] 发送失败: " + result);
+                return false;
+            }
+            
+            // Debug.Log("[P2P发包] 发送成功，消息编号: " + messageNumber);
+            return true;
+        }
+
+        public void BroadcastPacket(byte[] data, int length, int sendFlags = Constants.k_nSteamNetworkingSend_Reliable)
+        {
+            // Debug.Log("[P2P广播] 广播数据包，目标数量: " + peerConnections.Count + ", 大小: " + length + " bytes");
+            int successCount = 0;
+            
+            foreach (var peer in peerConnections.Keys)
+            {
+                if (SendPacket(peer, data, length, sendFlags))
+                {
+                    successCount++;
+                }
+            }
+            
+            // Debug.Log("[P2P广播] 广播完成，成功: " + successCount + "/" + peerConnections.Count);
+        }
+
+        private void ReceiveMessages()
+        {
+            int totalReceived = 0;
+            
+            foreach (var kvp in peerConnections)
+            {
+                HSteamNetConnection conn = kvp.Value;
+                CSteamID peer = kvp.Key;
+                
+                int numMessages = SteamNetworkingSockets.ReceiveMessagesOnConnection(conn, messageBuffers, messageBuffers.Length);
+                
+                if (numMessages > 0)
+                {
+                    // Debug.Log("[P2P收包] 从 " + peer + " 收到 " + numMessages + " 个消息");
+                    
+                    for (int i = 0; i < numMessages; i++)
+                    {
+                        IntPtr msgPtr = messageBuffers[i];
+                        SteamNetworkingMessage_t msg = SteamNetworkingMessage_t.FromIntPtr(msgPtr);
+                        
+                        int size = msg.m_cbSize;
+                        byte[] data = new byte[size];
+                        System.Runtime.InteropServices.Marshal.Copy(msg.m_pData, data, 0, size);
+                        
+                        
+                        if (size > 0 && (data[0] == 255 || data[0] == 254 || data[0] == 253))
+                        {
+                            if (data[0] == 255)
+                            {
+                                ProcessPingPacket(peer, data);
+                            }
+                            else if (data[0] == 254)
+                            {
+                                ProcessPongPacket(peer, data);
+                            }
+                            else if (data[0] == 253)
+                            {
+                                Debug.Log("[P2P收包] ==================== 收到欢迎消息 ====================");
+                                Debug.Log("[P2P收包] 来自: " + peer);
+                                Debug.Log("[P2P收包] 连接完全建立！");
+                            }
+                        }
+                        else
+                        {
+                            // Debug.Log("[P2P收包] 消息 #" + (i + 1) + ", 大小: " + size + " bytes");
+                            OnDataReceived?.Invoke(peer, data, size);
+                        }
+                        
+                        // 释放消息
+                        SteamNetworkingMessage_t.Release(msgPtr);
+                    }
+                    
+                    totalReceived += numMessages;
+                }
+            }
+            
+            // if (totalReceived > 0)
+            // {
+            //     Debug.Log("[P2P收包] 本帧共收到 " + totalReceived + " 个数据包");
+            // }
+        }
+
+        #endregion
+
+        #region Steam回调处理
+
+        private void OnConnectionStatusChanged(SteamNetConnectionStatusChangedCallback_t callback)
+        {
+            Debug.Log("[SteamNetSockets] ==================== 连接状态变更 ====================");
+            Debug.Log("[SteamNetSockets] 连接: " + callback.m_hConn.m_HSteamNetConnection);
+            Debug.Log("[SteamNetSockets] 旧状态: " + callback.m_eOldState);
+            Debug.Log("[SteamNetSockets] 新状态: " + callback.m_info.m_eState);
+            
+            HSteamNetConnection conn = callback.m_hConn;
+            SteamNetConnectionInfo_t info = callback.m_info;
+            
+            switch (info.m_eState)
+            {
+                case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_Connecting:
+                    Debug.Log("[SteamNetSockets] 连接中...");
+                    Debug.Log("[SteamNetSockets] 当前isServer=" + isServer);
+                    if (isServer)
+                    {
+                        CSteamID remoteSteamId = info.m_identityRemote.GetSteamID();
+                        Debug.Log("[SteamNetSockets] 服务器接受来自 " + remoteSteamId + " 的连接");
+                        
+                        EResult result = SteamNetworkingSockets.AcceptConnection(conn);
+                        Debug.Log("[SteamNetSockets] AcceptConnection结果: " + result);
+                        
+                        if (result == EResult.k_EResultOK)
+                        {
+                            peerConnections[remoteSteamId] = conn;
+                            connectionToPeer[conn] = remoteSteamId;
+                            Debug.Log("[SteamNetSockets] 连接已接受并记录: " + remoteSteamId);
+                        }
+                        else
+                        {
+                            Debug.LogError("[SteamNetSockets] 接受连接失败: " + result);
+                        }
+                    }
+                    else
+                    {
+                        Debug.Log("[SteamNetSockets] 客户端等待连接建立...");
+                    }
+                    break;
+                    
+                case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_Connected:
+                    Debug.Log("[SteamNetSockets] 连接已建立");
+                    CSteamID connectedPeer = info.m_identityRemote.GetSteamID();
+                    Debug.Log("[SteamNetSockets] 对方SteamID: " + connectedPeer);
+                    
+                    if (isServer)
+                    {
+                        Debug.Log("[SteamNetSockets] 服务器向客户端 " + connectedPeer + " 发送欢迎消息");
+                        byte[] welcomeData = new byte[1];
+                        welcomeData[0] = 253;
+                        SendPacket(connectedPeer, welcomeData, 1, Constants.k_nSteamNetworkingSend_Reliable);
+                    }
+                    else
+                    {
+                        Debug.Log("[SteamNetSockets] 客户端已成功连接到服务器");
+                    }
+                    
+                    OnPeerConnected?.Invoke(connectedPeer);
+                    break;
+                    
+                case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ClosedByPeer:
+                case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ProblemDetectedLocally:
+                    Debug.Log("[SteamNetSockets] 连接关闭");
+                    Debug.Log("[SteamNetSockets] 原因: " + info.m_eEndReason + " - " + info.m_szEndDebug);
+                    
+                    if (connectionToPeer.TryGetValue(conn, out CSteamID disconnectedPeer))
+                    {
+                        peerConnections.Remove(disconnectedPeer);
+                        connectionToPeer.Remove(conn);
+                        Debug.Log("[SteamNetSockets] 移除连接: " + disconnectedPeer);
+                        OnPeerDisconnected?.Invoke(disconnectedPeer);
+                    }
+                    
+                    SteamNetworkingSockets.CloseConnection(conn, 0, "", false);
+                    break;
+            }
+        }
+
+        private void OnLobbyCreatedCallback(LobbyCreated_t callback)
+        {
+            if (SteamP2PLoader.Instance != null && SteamP2PLoader.Instance.UseSteamP2P)
+            {
+                Debug.Log("[SteamNetSockets] 虚拟网络P2P模式已启用，跳过混合模式大厅创建处理");
+                return;
+            }
+            
+            Debug.Log("[SteamNetSockets] ==================== 大厅创建回调 ====================");
+            Debug.Log("[SteamNetSockets] 结果: " + callback.m_eResult);
+            
+            if (callback.m_eResult == EResult.k_EResultOK)
+            {
+                currentLobbyId = new CSteamID(callback.m_ulSteamIDLobby);
+                isServer = true;
+                
+                Debug.Log("[SteamNetSockets] 大厅创建成功，ID: " + currentLobbyId);
+                Debug.Log("[SteamNetSockets] 已设置为主机模式 isServer = true");
+                
+                SetLobbyData(LOBBY_MOD_ID_KEY, MOD_IDENTIFIER);
+                if (!string.IsNullOrEmpty(currentLobbyName))
+                {
+                    SetLobbyData(LOBBY_NAME_KEY, currentLobbyName);
+                }
+                if (!string.IsNullOrEmpty(currentLobbyPassword))
+                {
+                    SetLobbyData(LOBBY_PASSWORD_KEY, currentLobbyPassword);
+                }
+                
+                if (listenSocket == HSteamListenSocket.Invalid)
+                {
+                    Debug.Log("[SteamNetSockets] 大厅创建后启动服务器模式");
+                    StartServer();
+                }
+                
+                OnLobbyCreated?.Invoke(currentLobbyId);
+            }
+            else
+            {
+                Debug.LogError("[SteamNetSockets] 大厅创建失败: " + callback.m_eResult);
+            }
+        }
+
+        private void OnLobbyEnterCallback(LobbyEnter_t callback)
+        {
+            if (SteamP2PLoader.Instance != null && SteamP2PLoader.Instance.UseSteamP2P)
+            {
+                Debug.Log("[SteamNetSockets] 虚拟网络P2P模式已启用，跳过混合模式大厅加入处理");
+                return;
+            }
+            
+            Debug.Log("[SteamNetSockets] ==================== 进入大厅回调 ====================");
+            Debug.Log("[SteamNetSockets] 大厅ID: " + callback.m_ulSteamIDLobby);
+            Debug.Log("[SteamNetSockets] 响应: " + callback.m_EChatRoomEnterResponse);
+            
+            if (callback.m_EChatRoomEnterResponse == (uint)EChatRoomEnterResponse.k_EChatRoomEnterResponseSuccess)
+            {
+                currentLobbyId = new CSteamID(callback.m_ulSteamIDLobby);
+                
+                // 检查密码
+                string lobbyPassword = GetLobbyData(LOBBY_PASSWORD_KEY);
+                if (!string.IsNullOrEmpty(lobbyPassword) && lobbyPassword != currentLobbyPassword)
+                {
+                    Debug.LogError("[SteamNetSockets] 密码错误");
+                    LeaveLobby();
+                    return;
+                }
+                
+                Debug.Log("[SteamNetSockets] 成功进入大厅");
+                
+                // 如果不是服务器，连接到主机
+                if (!isServer)
+                {
+                    CSteamID hostId = SteamMatchmaking.GetLobbyOwner(currentLobbyId);
+                    Debug.Log("[SteamNetSockets] 主机SteamID: " + hostId);
+                    ConnectToHost(hostId);
+                }
+                
+                OnLobbyJoined?.Invoke(currentLobbyId);
+            }
+            else
+            {
+                Debug.LogError("[SteamNetSockets] 进入大厅失败: " + callback.m_EChatRoomEnterResponse);
+            }
+        }
+
+        private void OnLobbyChatUpdateCallback(LobbyChatUpdate_t callback)
+        {
+            Debug.Log("[SteamNetSockets] 大厅成员变更: " + callback.m_ulSteamIDUserChanged);
+            Debug.Log("[SteamNetSockets] 变更类型: " + callback.m_rgfChatMemberStateChange);
+            
+            // 可以在这里处理玩家加入/离开事件
+        }
+
+        private void OnLobbyMatchListCallback(LobbyMatchList_t callback)
+        {
+            Debug.Log("[SteamNetSockets] 收到大厅列表，数量: " + callback.m_nLobbiesMatching);
+            
+            List<LobbyInfo> lobbies = new List<LobbyInfo>();
+            
+            for (int i = 0; i < callback.m_nLobbiesMatching; i++)
+            {
+                CSteamID lobbyId = SteamMatchmaking.GetLobbyByIndex(i);
+                string modId = SteamMatchmaking.GetLobbyData(lobbyId, LOBBY_MOD_ID_KEY);
+                
+                // 只显示匹配的mod
+                if (modId == MOD_IDENTIFIER)
+                {
+                    string ownerName = SteamFriends.GetFriendPersonaName(SteamMatchmaking.GetLobbyOwner(lobbyId));
+                    string lobbyName = SteamMatchmaking.GetLobbyData(lobbyId, LOBBY_NAME_KEY);
+                    if (string.IsNullOrEmpty(lobbyName))
+                    {
+                        lobbyName = ownerName + "的房间";
+                    }
+                    
+                    LobbyInfo info = new LobbyInfo
+                    {
+                        LobbyId = lobbyId,
+                        LobbyName = lobbyName,
+                        OwnerName = ownerName,
+                        CurrentPlayers = SteamMatchmaking.GetNumLobbyMembers(lobbyId),
+                        MaxPlayers = SteamMatchmaking.GetLobbyMemberLimit(lobbyId),
+                        HasPassword = !string.IsNullOrEmpty(SteamMatchmaking.GetLobbyData(lobbyId, LOBBY_PASSWORD_KEY))
+                    };
+                    
+                    lobbies.Add(info);
+                }
+            }
+            
+            Debug.Log("[SteamNetSockets] 匹配的大厅数: " + lobbies.Count);
+            OnLobbyListReceived?.Invoke(lobbies);
+        }
+
+        private void OnGameLobbyJoinRequestedCallback(GameLobbyJoinRequested_t callback)
+        {
+            Debug.Log("[SteamNetSockets] 收到加入大厅请求: " + callback.m_steamIDLobby);
+            JoinLobby(callback.m_steamIDLobby);
+        }
+
+        #endregion
+
+        private void OnDestroy()
+        {
+            CloseAllConnections();
+        }
+    }
+
+    public class LobbyInfo
+    {
+        public CSteamID LobbyId;
+        public string LobbyName;
+        public string OwnerName;
+        public int CurrentPlayers;
+        public int MaxPlayers;
+        public bool HasPassword;
+        public bool IsCompatibleMod = true;
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/Steam/SteamP2PLoader.cs
+++ b/EscapeFromDuckovCoopMod/Net/Steam/SteamP2PLoader.cs
@@ -1,0 +1,92 @@
+// Escape-From-Duckov-Coop-Mod-Preview
+// Copyright (C) 2025  Mr.sans and InitLoader's team
+
+using System;
+using UnityEngine;
+
+namespace EscapeFromDuckovCoopMod.Net.Steam
+{
+    public class SteamP2PLoader : MonoBehaviour
+    {
+        public static SteamP2PLoader Instance { get; private set; }
+        
+        public bool UseSteamP2P = true;
+        public bool FallbackToUDP = true;
+        
+        public void Init()
+        {
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            InitializeMod();
+        }
+        
+        private void InitializeMod()
+        {
+            try
+            {
+                Debug.Log("[SteamP2P扩展] 开始初始化...");
+                
+                if (!SteamManager.Initialized)
+                {
+                    Debug.LogWarning("[SteamP2P扩展] Steam未初始化，将使用UDP模式");
+                    UseSteamP2P = false;
+                    
+                    if (!FallbackToUDP)
+                    {
+                        Debug.LogError("[SteamP2P扩展] Steam不可用且禁用了UDP回退，MOD将不工作");
+                        return;
+                    }
+                }
+                
+                if (UseSteamP2P && SteamManager.Initialized)
+                {
+                    gameObject.AddComponent<SteamP2PManager>();
+                    gameObject.AddComponent<SteamEndPointMapper>();
+                    gameObject.AddComponent<SteamLobbyManager>();
+                    
+                    Debug.Log("[SteamP2P扩展] Steam P2P组件已启动");
+                }
+                
+                Debug.Log("[SteamP2P扩展] 初始化完成！按F9使用Steam邀请好友");
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("[SteamP2P扩展] 初始化失败: " + ex);
+            }
+        }
+        
+        private void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.F9))
+            {
+                if (SteamLobbyManager.Instance != null)
+                {
+                    SteamLobbyManager.Instance.InviteFriend();
+                    Debug.Log("[SteamP2P扩展] 打开Steam邀请界面（Shift+Tab也可以）");
+                }
+            }
+            
+            if (Input.GetKeyDown(KeyCode.F10))
+            {
+                if (SteamP2PManager.Instance != null)
+                {
+                    Debug.Log("========== Steam P2P 连接统计 ==========");
+                    Debug.Log("发送: " + SteamP2PManager.Instance.PacketsSent + " 包, " + SteamP2PManager.Instance.BytesSent + " bytes");
+                    Debug.Log("接收: " + SteamP2PManager.Instance.PacketsReceived + " 包, " + SteamP2PManager.Instance.BytesReceived + " bytes");
+                    Debug.Log("队列: " + SteamP2PManager.Instance.GetQueueSize() + " 个待处理数据包");
+                    
+                    if (SteamEndPointMapper.Instance != null)
+                    {
+                        var steamIDs = SteamEndPointMapper.Instance.GetAllSteamIDs();
+                        Debug.Log("连接数: " + steamIDs.Count);
+                        foreach (var steamID in steamIDs)
+                        {
+                            Debug.Log("  - " + steamID);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/Steam/SteamP2PManager.cs
+++ b/EscapeFromDuckovCoopMod/Net/Steam/SteamP2PManager.cs
@@ -1,36 +1,348 @@
 // Escape-From-Duckov-Coop-Mod-Preview
 // Copyright (C) 2025  Mr.sans and InitLoader's team
-//
-// This program is not a free software.
-// It's distributed under a license based on AGPL-3.0,
-// with strict additional restrictions:
-//  YOU MUST NOT use this software for commercial purposes.
-//  YOU MUST NOT use this software to run a headless game server.
-//  YOU MUST include a conspicuous notice of attribution to
-//  Mr-sans-and-InitLoader-s-team/Escape-From-Duckov-Coop-Mod-Preview as the original author.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
 
 ﻿using Steamworks;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Net;
 using UnityEngine;
 
-namespace EscapeFromDuckovCoopMod
+namespace EscapeFromDuckovCoopMod.Net.Steam
 {
-    public class SteamP2PManager
+    public class SteamP2PManager : MonoBehaviour
     {
-
-
-
-
-
-
+        public static SteamP2PManager Instance { get; private set; }
+        
+        private Callback<P2PSessionRequest_t> _p2pSessionRequestCallback;
+        private Callback<P2PSessionConnectFail_t> _p2pSessionConnectFailCallback;
+        
+        private byte[] _receiveBuffer = new byte[1432];
+        private byte[] _largeReceiveBuffer = new byte[8192];
+        private ConcurrentQueue<ReceivedPacket> _receivedPackets = new ConcurrentQueue<ReceivedPacket>();
+        
+        private const int MAX_QUEUE_SIZE = 512;
+        private const int BATCH_PROCESS_LIMIT = 512;
+        
+        private int _packetsSent;
+        private int _packetsReceived;
+        private long _bytesSent;
+        private long _bytesReceived;
+        
+        public int PacketsSent => _packetsSent;
+        public int PacketsReceived => _packetsReceived;
+        public long BytesSent => _bytesSent;
+        public long BytesReceived => _bytesReceived;
+        public int PacketsDropped { get; private set; }
+        public int SendFailures { get; private set; }
+        public int MaxQueueDepth { get; private set; }
+        
+        private struct ReceivedPacket
+        {
+            public byte[] Data;
+            public int Length;
+            public CSteamID RemoteSteamID;
+        }
+        
+        private void Awake()
+        {
+            if (Instance != null)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            InitializeSteamCallbacks();
+        }
+        
+        private void InitializeSteamCallbacks()
+        {
+            if (!SteamManager.Initialized)
+            {
+                Debug.LogError("[SteamP2P] Steam未初始化，无法设置回调");
+                return;
+            }
+            
+            SteamNetworking.AllowP2PPacketRelay(true);
+            Debug.Log("[SteamP2P] 已启用中继服务器（用于NAT穿透）");
+            
+            _p2pSessionRequestCallback = Callback<P2PSessionRequest_t>.Create(OnP2PSessionRequest);
+            _p2pSessionConnectFailCallback = Callback<P2PSessionConnectFail_t>.Create(OnP2PSessionConnectFail);
+            
+            Debug.Log("[SteamP2P] Steam回调已设置");
+        }
+        
+        private int _updateCount = 0;
+        
+        private void Update()
+        {
+            if (!SteamManager.Initialized || !SteamP2PLoader.Instance.UseSteamP2P)
+                return;
+                
+            _updateCount++;
+            if (_updateCount % 1800 == 0)
+            {
+                if (PacketsReceived == 0 && PacketsSent > 10)
+                {
+                    Debug.LogWarning("[SteamP2P] 已发送 " + PacketsSent + " 包，但未收到任何回复！");
+                }
+            }
+        }
+        
+        private HashSet<CSteamID> _acceptedSessions = new HashSet<CSteamID>();
+        
+        public bool SendPacket(CSteamID targetSteamID, byte[] data, int offset, int length, EP2PSend sendType = EP2PSend.k_EP2PSendUnreliableNoDelay)
+        {
+            if (!SteamManager.Initialized)
+            {
+                Debug.LogError("[SteamP2P] Steam未初始化");
+                return false;
+            }
+            
+            if (!_acceptedSessions.Contains(targetSteamID))
+            {
+                SteamNetworking.AcceptP2PSessionWithUser(targetSteamID);
+                _acceptedSessions.Add(targetSteamID);
+            }
+            
+            bool success;
+            if (offset == 0)
+            {
+                success = SteamNetworking.SendP2PPacket(targetSteamID, data, (uint)length, sendType, 0);
+            }
+            else
+            {
+                byte[] sendData = new byte[length];
+                Array.Copy(data, offset, sendData, 0, length);
+                success = SteamNetworking.SendP2PPacket(targetSteamID, sendData, (uint)length, sendType, 0);
+            }
+            
+            if (success)
+            {
+                System.Threading.Interlocked.Increment(ref _packetsSent);
+                System.Threading.Interlocked.Add(ref _bytesSent, length);
+            }
+            else
+            {
+                SendFailures++;
+                if (SendFailures == 1 || SendFailures % 10 == 0)
+                {
+                    if (SteamNetworking.GetP2PSessionState(targetSteamID, out P2PSessionState_t sessionState))
+                    {
+                        Debug.LogWarning("[SteamP2P] 发送失败#" + SendFailures + " to " + targetSteamID + " | 连接:" + sessionState.m_bConnectionActive + " | 队列:" + sessionState.m_nBytesQueuedForSend + "B");
+                    }
+                }
+            }
+            
+            return success;
+        }
+        
+        public bool TryGetReceivedPacket(out byte[] data, out int length, out CSteamID remoteSteamID)
+        {
+            if (_receivedPackets.TryDequeue(out ReceivedPacket packet))
+            {
+                data = packet.Data;
+                length = packet.Length;
+                remoteSteamID = packet.RemoteSteamID;
+                return true;
+            }
+            
+            data = null;
+            length = 0;
+            remoteSteamID = CSteamID.Nil;
+            return false;
+        }
+        
+        public int GetQueueSize()
+        {
+            return _receivedPackets.Count;
+        }
+        
+        public bool TryReceiveDirectFromSteam(byte[] buffer, int offset, int maxSize, out int length, out CSteamID remoteSteamID, out IPEndPoint endPoint)
+        {
+            length = 0;
+            remoteSteamID = CSteamID.Nil;
+            endPoint = null;
+            
+            if (!SteamManager.Initialized)
+                return false;
+                
+            try
+            {
+                const int channel = 0;
+                if (SteamNetworking.IsP2PPacketAvailable(out uint packetSize, channel))
+                {
+                    byte[] tempBuffer;
+                    if (packetSize <= _receiveBuffer.Length)
+                    {
+                        tempBuffer = _receiveBuffer;
+                    }
+                    else if (packetSize <= _largeReceiveBuffer.Length)
+                    {
+                        tempBuffer = _largeReceiveBuffer;
+                    }
+                    else
+                    {
+                        tempBuffer = new byte[packetSize];
+                    }
+                    
+                    if (SteamNetworking.ReadP2PPacket(tempBuffer, packetSize, out uint bytesRead, out remoteSteamID, channel))
+                    {
+                        if (bytesRead == 9 && System.Text.Encoding.UTF8.GetString(tempBuffer, 0, 9) == "HANDSHAKE")
+                        {
+                            return false;
+                        }
+                        
+                        int copySize = (int)Math.Min(bytesRead, maxSize);
+                        Array.Copy(tempBuffer, 0, buffer, offset, copySize);
+                        length = copySize;
+                        
+                        if (SteamEndPointMapper.Instance != null)
+                        {
+                            if (!SteamEndPointMapper.Instance.TryGetEndPoint(remoteSteamID, out endPoint))
+                            {
+                                endPoint = SteamEndPointMapper.Instance.RegisterSteamID(remoteSteamID);
+                            }
+                        }
+                        
+                        System.Threading.Interlocked.Increment(ref _packetsReceived);
+                        System.Threading.Interlocked.Add(ref _bytesReceived, copySize);
+                        
+                        return endPoint != null;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("[SteamP2P] TryReceiveDirectFromSteam 异常: " + ex);
+            }
+            
+            return false;
+        }
+        
+        public void ClearAcceptedSession(CSteamID remoteSteamID)
+        {
+            _acceptedSessions.Remove(remoteSteamID);
+        }
+        
+        public bool AcceptP2PSession(CSteamID remoteSteamID)
+        {
+            if (!SteamManager.Initialized)
+                return false;
+            return SteamNetworking.AcceptP2PSessionWithUser(remoteSteamID);
+        }
+        
+        public bool CloseP2PSession(CSteamID remoteSteamID)
+        {
+            if (!SteamManager.Initialized)
+                return false;
+            return SteamNetworking.CloseP2PSessionWithUser(remoteSteamID);
+        }
+        
+        public bool GetP2PSessionState(CSteamID remoteSteamID, out P2PSessionState_t sessionState)
+        {
+            if (!SteamManager.Initialized)
+            {
+                sessionState = new P2PSessionState_t();
+                return false;
+            }
+            return SteamNetworking.GetP2PSessionState(remoteSteamID, out sessionState);
+        }
+        
+        #region Steam 回调处理
+        
+        private void OnP2PSessionRequest(P2PSessionRequest_t request)
+        {
+            Debug.Log("[SteamP2P] 收到P2P会话请求 from " + request.m_steamIDRemote);
+            
+            if (SteamNetworking.AcceptP2PSessionWithUser(request.m_steamIDRemote))
+            {
+                Debug.Log("[SteamP2P] 已接受P2P会话 from " + request.m_steamIDRemote);
+                
+                byte[] handshake = System.Text.Encoding.UTF8.GetBytes("HANDSHAKE");
+                for (int i = 0; i < 3; i++)
+                {
+                    SteamNetworking.SendP2PPacket(request.m_steamIDRemote, handshake, (uint)handshake.Length,
+                        EP2PSend.k_EP2PSendUnreliableNoDelay, 0);
+                }
+                
+                bool sent = SteamNetworking.SendP2PPacket(request.m_steamIDRemote, handshake, (uint)handshake.Length,
+                    EP2PSend.k_EP2PSendReliable, 0);
+                    
+                Debug.Log("[SteamP2P] NAT穿透握手完成: " + (sent ? "成功" : "失败"));
+                
+                if (SteamEndPointMapper.Instance != null)
+                {
+                    SteamEndPointMapper.Instance.OnP2PSessionEstablished(request.m_steamIDRemote);
+                }
+            }
+            else
+            {
+                Debug.LogError("[SteamP2P] 接受P2P会话失败 from " + request.m_steamIDRemote);
+            }
+        }
+        
+        private void OnP2PSessionConnectFail(P2PSessionConnectFail_t failure)
+        {
+            string errorMsg;
+            switch (failure.m_eP2PSessionError)
+            {
+                case 0:
+                    errorMsg = "None";
+                    break;
+                case 1:
+                    errorMsg = "TargetNotRunning - 目标未运行Steam";
+                    break;
+                case 2:
+                    errorMsg = "NoRightsToApp - 无权访问应用";
+                    break;
+                case 3:
+                    errorMsg = "DestinationNotLoggedIn - 目标未登录";
+                    break;
+                case 4:
+                    errorMsg = "Timeout - 连接超时（可能NAT穿透失败）";
+                    break;
+                default:
+                    errorMsg = "Unknown(" + failure.m_eP2PSessionError + ")";
+                    break;
+            }
+            
+            Debug.LogError("[SteamP2P] P2P连接失败: " + failure.m_steamIDRemote);
+            Debug.LogError("[SteamP2P] 错误原因: " + errorMsg);
+            
+            if (SteamEndPointMapper.Instance != null)
+            {
+                SteamEndPointMapper.Instance.OnP2PSessionFailed(failure.m_steamIDRemote);
+            }
+        }
+        
+        #endregion
+        
+        private void OnDestroy()
+        {
+            if (SteamManager.Initialized && SteamEndPointMapper.Instance != null)
+            {
+                var activeSessions = SteamEndPointMapper.Instance.GetAllSteamIDs();
+                if (activeSessions != null)
+                {
+                    foreach (var steamID in activeSessions)
+                    {
+                        SteamNetworking.CloseP2PSessionWithUser(steamID);
+                    }
+                }
+            }
+            
+            Debug.Log("[SteamP2P] ========== 会话统计 ==========");
+            Debug.Log("[SteamP2P] 发送: " + PacketsSent + "包 (" + BytesSent + "字节) | 失败: " + SendFailures);
+            Debug.Log("[SteamP2P] 接收: " + PacketsReceived + "包 (" + BytesReceived + "字节) | 丢包: " + PacketsDropped);
+            Debug.Log("[SteamP2P] 队列峰值: " + MaxQueueDepth + "/" + MAX_QUEUE_SIZE);
+            
+            float lossRate = PacketsReceived > 0 ? (PacketsDropped * 100f / (PacketsReceived + PacketsDropped)) : 0;
+            float failRate = PacketsSent > 0 ? (SendFailures * 100f / (PacketsSent + SendFailures)) : 0;
+            
+            Debug.Log("[SteamP2P] 接收丢包率: " + lossRate.ToString("F2") + "% | 发送失败率: " + failRate.ToString("F2") + "%");
+            Debug.Log("[SteamP2P] ================================");
+        }
     }
 }

--- a/EscapeFromDuckovCoopMod/NetTag/NetDestructibleTag.cs
+++ b/EscapeFromDuckovCoopMod/NetTag/NetDestructibleTag.cs
@@ -53,7 +53,7 @@ namespace EscapeFromDuckovCoopMod
             int py = Mathf.RoundToInt(p.y * 100f);
             int pz = Mathf.RoundToInt(p.z * 100f);
 
-            string key = $"{sceneIndex}:{sb}:{px},{py},{pz}";
+            string key = sceneIndex + ":" + sb + ":" + px + "," + py + "," + pz;
 
             // FNV1a-32 可能有用 by:InitLoader 
             unchecked

--- a/EscapeFromDuckovCoopMod/Patch/Item_/ItemUtilitiesPatch.cs
+++ b/EscapeFromDuckovCoopMod/Patch/Item_/ItemUtilitiesPatch.cs
@@ -209,7 +209,7 @@ namespace EscapeFromDuckovCoopMod
 
             if (srcLoot && LootboxDetectUtil.IsLootboxInventory(srcLoot) && !LootboxDetectUtil.IsPrivateInventory(srcLoot))
             {
-                Debug.Log($"[Coop] AddAndMerge(slot->backpack) -> UNPLUG(takeToBackpack), prefer={preferedFirstPosition}");
+                Debug.Log("[Coop] AddAndMerge(slot->backpack) -> UNPLUG(takeToBackpack), prefer=" + preferedFirstPosition);
                 // 直接携带目标格（preferedFirstPosition）做精确落位
                 COOPManager.LootNet.Client_RequestSlotUnplugToBackpack(srcLoot, master, slot.Key, inventory, preferedFirstPosition);
                 __result = true;

--- a/EscapeFromDuckovCoopMod/Patch/Scene/ScenePatch.cs
+++ b/EscapeFromDuckovCoopMod/Patch/Scene/ScenePatch.cs
@@ -90,7 +90,7 @@ namespace EscapeFromDuckovCoopMod
                 //try
                 //{
                 //    // Host 的 EndPoint 在初始化时就是 "Host:{port}"（见d1 Mod.cs.InitializeLocalPlayer）
-                //    string hostKey = $"Host:{mod.port}";
+                //    string hostKey = "Host:" + mod.port;
 
                 //    if (mod.clientRemoteCharacters != null &&
                 //        mod.clientRemoteCharacters.TryGetValue(hostKey, out var hostProxy) &&
@@ -112,11 +112,11 @@ namespace EscapeFromDuckovCoopMod
 
                 //if (allowClientVote)
                 //{
-                //    Debug.Log($"[SCENE] 客户端放行切图（允许投票）：target={targetId}, hostMissing={hostMissing}, hostNotInGame={hostNotInGame}, hostSceneDiff={hostSceneDiff}");
+                //    Debug.Log("[SCENE] 客户端放行切图（允许投票）：target=" + targetId + ", hostMissing=" + hostMissing + ", hostNotInGame=" + hostNotInGame + ", hostSceneDiff=" + hostSceneDiff);
                 //    mod.Client_RequestBeginSceneVote(targetId, curtainGuid, notifyEvac, save, useLoc, locationName);
                 //    return false;
                 //}
-                Debug.Log($"[SCENE] 客户端放行切图（允许投票）：target={targetId}");
+                Debug.Log("[SCENE] 客户端放行切图（允许投票）：target=" + targetId);
                 return false;
             }
         }

--- a/EscapeFromDuckovCoopMod/Patch/SteamP2P/PacketSignature.cs
+++ b/EscapeFromDuckovCoopMod/Patch/SteamP2P/PacketSignature.cs
@@ -1,0 +1,82 @@
+// Escape-From-Duckov-Coop-Mod-Preview
+// Copyright (C) 2025  Mr.sans and InitLoader's team
+
+using LiteNetLib;
+using System;
+using System.Collections.Concurrent;
+
+namespace EscapeFromDuckovCoopMod.Patch.SteamP2P
+{
+    public static class PacketSignature
+    {
+        private static readonly ConcurrentDictionary<ulong, DeliveryMethod> _signatures =
+            new ConcurrentDictionary<ulong, DeliveryMethod>();
+        private static int _cleanupCounter = 0;
+        private const int CLEANUP_THRESHOLD = 10000;
+        
+        public static ulong CalculateSignature(byte[] data, int start, int length)
+        {
+            if (data == null || length == 0)
+                return 0;
+                
+            ulong hash = (ulong)length;
+            int bytesToHash = Math.Min(8, length);
+            
+            for (int i = 0; i < bytesToHash; i++)
+            {
+                int index = start + i;
+                if (index < data.Length)
+                {
+                    hash = hash * 31 + data[index];
+                }
+            }
+            
+            return hash;
+        }
+        
+        public static void Register(byte[] data, int start, int length, DeliveryMethod deliveryMethod)
+        {
+            if (data == null || length == 0)
+                return;
+                
+            ulong signature = CalculateSignature(data, start, length);
+            _signatures[signature] = deliveryMethod;
+            
+            _cleanupCounter++;
+            if (_cleanupCounter >= CLEANUP_THRESHOLD)
+            {
+                Cleanup();
+                _cleanupCounter = 0;
+            }
+        }
+        
+        public static DeliveryMethod? TryGetDeliveryMethod(byte[] data, int start, int length)
+        {
+            if (data == null || length == 0)
+                return null;
+                
+            ulong signature = CalculateSignature(data, start, length);
+            if (_signatures.TryGetValue(signature, out DeliveryMethod method))
+            {
+                _signatures.TryRemove(signature, out _);
+                return method;
+            }
+            
+            return null;
+        }
+        
+        private static void Cleanup()
+        {
+            if (_signatures.Count > 1000)
+            {
+                _signatures.Clear();
+            }
+        }
+        
+        public static int GetSignatureCount()
+        {
+            return _signatures.Count;
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Patch/SteamP2P/Patch_LiteNetLib.cs
+++ b/EscapeFromDuckovCoopMod/Patch/SteamP2P/Patch_LiteNetLib.cs
@@ -1,0 +1,65 @@
+// Escape-From-Duckov-Coop-Mod-Preview
+// Copyright (C) 2025  Mr.sans and InitLoader's team
+
+using HarmonyLib;
+using LiteNetLib;
+using LiteNetLib.Utils;
+using Steamworks;
+using System;
+using System.Net;
+using UnityEngine;
+
+namespace EscapeFromDuckovCoopMod.Patch.SteamP2P
+{
+    // NetManager.Connect - 拦截连接请求，在Steam Lobby中自动注册虚拟IP
+    [HarmonyPatch(typeof(NetManager), "Connect", new Type[] { typeof(string), typeof(int), typeof(NetDataWriter) })]
+    public class Patch_NetManager_Connect
+    {
+        static bool Prefix(string address, int port, NetDataWriter connectionData, ref NetPeer __result)
+        {
+            if (!Net.Steam.SteamP2PLoader.Instance.UseSteamP2P || !SteamManager.Initialized)
+                return true;
+                
+            try
+            {
+                Debug.Log("[Patch_Connect] 尝试连接到: " + address + ":" + port);
+                
+                if (Net.Steam.SteamLobbyManager.Instance != null && Net.Steam.SteamLobbyManager.Instance.IsInLobby)
+                {
+                    CSteamID hostSteamID = Net.Steam.SteamLobbyManager.Instance.GetLobbyOwner();
+                    if (hostSteamID != CSteamID.Nil)
+                    {
+                        Debug.Log("[Patch_Connect] 检测到Lobby连接，主机Steam ID: " + hostSteamID);
+                        
+                        if (Net.Steam.SteamEndPointMapper.Instance != null)
+                        {
+                            IPEndPoint virtualEndPoint = Net.Steam.SteamEndPointMapper.Instance.RegisterSteamID(hostSteamID, port);
+                            Debug.Log("[Patch_Connect] 主机映射为虚拟IP: " + virtualEndPoint);
+                        }
+                    }
+                }
+                
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("[Patch_Connect] 异常: " + ex);
+                return true;
+            }
+        }
+    }
+    
+    // NetPeer.SendInternal - 记录数据包签名，用于后续识别传输模式
+    [HarmonyPatch(typeof(NetPeer), "SendInternal", MethodType.Normal)]
+    public class Patch_NetPeer_Send
+    {
+        private static int _patchedCount = 0;
+        
+        static void Prefix(byte[] data, int start, int length, DeliveryMethod deliveryMethod)
+        {
+            PacketSignature.Register(data, start, length, deliveryMethod);
+            _patchedCount++;
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Patch/SteamP2P/Patch_Socket.cs
+++ b/EscapeFromDuckovCoopMod/Patch/SteamP2P/Patch_Socket.cs
@@ -1,0 +1,345 @@
+// Escape-From-Duckov-Coop-Mod-Preview
+// Copyright (C) 2025  Mr.sans and InitLoader's team
+
+using HarmonyLib;
+using LiteNetLib;
+using Steamworks;
+using System;
+using System.Collections;
+using System.Net;
+using System.Net.Sockets;
+using System.Reflection;
+using UnityEngine;
+
+namespace EscapeFromDuckovCoopMod.Patch.SteamP2P
+{
+    // Socket.Available - 检查是否有数据可读
+    [HarmonyPatch(typeof(Socket), "get_Available")]
+    public class Patch_Socket_Available
+    {
+        static void Postfix(Socket __instance, ref int __result)
+        {
+            if (!Net.Steam.SteamP2PLoader.Instance.UseSteamP2P || !SteamManager.Initialized)
+                return;
+                
+            try
+            {
+                if (__result > 0)
+                    return;
+                    
+                if (SteamManager.Initialized && SteamNetworking.IsP2PPacketAvailable(out uint packetSize, 0))
+                {
+                    __result = (int)packetSize;
+                }
+                else if (Net.Steam.SteamP2PManager.Instance != null)
+                {
+                    int queueSize = Net.Steam.SteamP2PManager.Instance.GetQueueSize();
+                    if (queueSize > 0)
+                    {
+                        __result = queueSize * 200;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("[Patch_Available] 异常: " + ex);
+            }
+        }
+    }
+    
+    // Socket.Poll - 检查Socket状态
+    [HarmonyPatch(typeof(Socket), nameof(Socket.Poll))]
+    public class Patch_Socket_Poll
+    {
+        [ThreadStatic]
+        private static bool _inPatch = false;
+        
+        static bool Prefix(Socket __instance, ref int microSeconds, SelectMode mode, ref bool __result)
+        {
+            if (_inPatch)
+                return true;
+                
+            if (!Net.Steam.SteamP2PLoader.Instance.UseSteamP2P || !SteamManager.Initialized)
+                return true;
+                
+            try
+            {
+                _inPatch = true;
+                
+                if (mode != SelectMode.SelectRead)
+                    return true;
+                    
+                if (SteamManager.Initialized && SteamNetworking.IsP2PPacketAvailable(out uint packetSize, 0))
+                {
+                    __result = true;
+                    return false;
+                }
+                else if (Net.Steam.SteamP2PManager.Instance != null)
+                {
+                    int queueSize = Net.Steam.SteamP2PManager.Instance.GetQueueSize();
+                    if (queueSize > 0)
+                    {
+                        __result = true;
+                        return false;
+                    }
+                }
+                
+                if (microSeconds > 100)
+                {
+                    microSeconds = 100;
+                }
+                
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("[Patch_Poll] 异常: " + ex);
+                return true;
+            }
+            finally
+            {
+                _inPatch = false;
+            }
+        }
+    }
+    
+    // Socket.ReceiveFrom - 接收数据
+    [HarmonyPatch]
+    public class Patch_Socket_ReceiveFrom
+    {
+        static MethodBase TargetMethod()
+        {
+            return AccessTools.Method(typeof(Socket), "ReceiveFrom", new Type[]
+            {
+                typeof(byte[]),
+                typeof(int),
+                typeof(int),
+                typeof(SocketFlags),
+                typeof(EndPoint).MakeByRefType()
+            });
+        }
+        
+        static bool Prefix(Socket __instance, byte[] buffer, int offset, int size, SocketFlags socketFlags, ref EndPoint remoteEP, ref int __result)
+        {
+            if (!Net.Steam.SteamP2PLoader.Instance.UseSteamP2P || !SteamManager.Initialized)
+                return true;
+                
+            try
+            {
+                if (Net.Steam.SteamP2PManager.Instance != null)
+                {
+                    if (Net.Steam.SteamP2PManager.Instance.TryReceiveDirectFromSteam(buffer, offset, size, out int receivedLength, out CSteamID steamID, out IPEndPoint endPoint))
+                    {
+                        remoteEP = endPoint;
+                        __result = receivedLength;
+                        return false;
+                    }
+                    
+                    if (Net.Steam.SteamP2PManager.Instance.TryGetReceivedPacket(out byte[] data, out int length, out CSteamID remoteSteamID))
+                    {
+                        if (length > size)
+                        {
+                            Debug.LogWarning("[Patch_ReceiveFrom] 接收的数据(" + length + " bytes)超过缓冲区大小(" + size + " bytes)");
+                            length = size;
+                        }
+                        
+                        Array.Copy(data, 0, buffer, offset, length);
+                        
+                        IPEndPoint virtualEndPoint = null;
+                        if (Net.Steam.SteamEndPointMapper.Instance != null)
+                        {
+                            if (!Net.Steam.SteamEndPointMapper.Instance.TryGetEndPoint(remoteSteamID, out virtualEndPoint))
+                            {
+                                virtualEndPoint = Net.Steam.SteamEndPointMapper.Instance.RegisterSteamID(remoteSteamID);
+                            }
+                        }
+                        
+                        if (virtualEndPoint != null)
+                        {
+                            remoteEP = virtualEndPoint;
+                            __result = length;
+                            return false;
+                        }
+                    }
+                }
+                
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("[Patch_ReceiveFrom] 异常: " + ex);
+                return true;
+            }
+        }
+    }
+    
+    // Socket.Select - 选择就绪的Socket
+    [HarmonyPatch(typeof(Socket), nameof(Socket.Select))]
+    public static class Patch_Socket_Select
+    {
+        static bool Prefix(IList checkRead, IList checkWrite, IList checkError, int microSeconds)
+        {
+            if (!Net.Steam.SteamP2PLoader.Instance.UseSteamP2P || !SteamManager.Initialized)
+            {
+                return true;
+            }
+            
+            try
+            {
+                if (SteamNetworking.IsP2PPacketAvailable(out _, 0))
+                {
+                    return false;
+                }
+                
+                System.Threading.Thread.Sleep(1);
+                checkRead?.Clear();
+                checkWrite?.Clear();
+                checkError?.Clear();
+                return false;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("[Patch_Socket_Select] 异常: " + ex);
+                return true;
+            }
+        }
+    }
+    
+    // Socket.SendTo - 发送数据
+    [HarmonyPatch]
+    public class Patch_Socket_SendTo
+    {
+        private static int _diagCount = 0;
+        
+        static MethodBase TargetMethod()
+        {
+            return AccessTools.Method(typeof(Socket), "SendTo", new Type[]
+            {
+                typeof(byte[]),
+                typeof(int),
+                typeof(int),
+                typeof(SocketFlags),
+                typeof(EndPoint)
+            });
+        }
+        
+        static bool Prefix(Socket __instance, byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint remoteEP, ref int __result)
+        {
+            if (!Net.Steam.SteamP2PLoader.Instance.UseSteamP2P || !SteamManager.Initialized)
+                return true;
+                
+            try
+            {
+                IPEndPoint ipEndPoint = remoteEP as IPEndPoint;
+                if (ipEndPoint == null)
+                {
+                    return true;
+                }
+                
+                if (Net.Steam.SteamEndPointMapper.Instance != null &&
+                    Net.Steam.SteamEndPointMapper.Instance.IsVirtualEndPoint(ipEndPoint))
+                {
+                    if (Net.Steam.SteamEndPointMapper.Instance.TryGetSteamID(ipEndPoint, out CSteamID targetSteamID))
+                    {
+                        DeliveryMethod? deliveryMethod = PacketSignature.TryGetDeliveryMethod(buffer, offset, size);
+                        _diagCount++;
+                        
+                        EP2PSend sendMode;
+                        if (deliveryMethod == null && size > offset)
+                        {
+                            byte packetProperty = (byte)(buffer[offset] & 0x1F);
+                            switch (packetProperty)
+                            {
+                                case 0:
+                                    deliveryMethod = DeliveryMethod.Unreliable;
+                                    break;
+                                case 1:
+                                    deliveryMethod = DeliveryMethod.ReliableOrdered;
+                                    break;
+                                case 2:
+                                    deliveryMethod = DeliveryMethod.ReliableOrdered;
+                                    break;
+                                case 3:
+                                case 4:
+                                    deliveryMethod = DeliveryMethod.Unreliable;
+                                    break;
+                                case 5:
+                                case 6:
+                                case 7:
+                                    deliveryMethod = DeliveryMethod.ReliableOrdered;
+                                    break;
+                                default:
+                                    deliveryMethod = DeliveryMethod.ReliableOrdered;
+                                    break;
+                            }
+                        }
+                        
+                        switch (deliveryMethod ?? DeliveryMethod.ReliableOrdered)
+                        {
+                            case DeliveryMethod.Unreliable:
+                                sendMode = EP2PSend.k_EP2PSendUnreliableNoDelay;
+                                break;
+                            case DeliveryMethod.Sequenced:
+                                sendMode = EP2PSend.k_EP2PSendUnreliableNoDelay;
+                                break;
+                            case DeliveryMethod.ReliableOrdered:
+                                sendMode = EP2PSend.k_EP2PSendReliable;
+                                break;
+                            case DeliveryMethod.ReliableUnordered:
+                                sendMode = EP2PSend.k_EP2PSendReliable;
+                                break;
+                            case DeliveryMethod.ReliableSequenced:
+                                sendMode = EP2PSend.k_EP2PSendReliable;
+                                break;
+                            default:
+                                sendMode = EP2PSend.k_EP2PSendReliable;
+                                break;
+                        }
+                        
+                        if (_diagCount % 1000 == 0)
+                        {
+                            if (SteamNetworking.GetP2PSessionState(targetSteamID, out P2PSessionState_t sessionState))
+                            {
+                                if (sessionState.m_nBytesQueuedForSend > 50000)
+                                {
+                                    Debug.LogWarning("[Patch_SendTo] 发送队列积压: " + sessionState.m_nBytesQueuedForSend + " bytes");
+                                }
+                            }
+                        }
+                        
+                        bool success = Net.Steam.SteamP2PManager.Instance.SendPacket(
+                            targetSteamID,
+                            buffer,
+                            offset,
+                            size,
+                            sendMode
+                        );
+                        
+                        if (success)
+                        {
+                            __result = size;
+                            return false;
+                        }
+                        else
+                        {
+                            Debug.LogError("[Patch_SendTo] Steam P2P发送失败！DeliveryMethod=" + deliveryMethod + ", Size=" + size);
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        Debug.LogWarning("[Patch_SendTo] 虚拟端点 " + ipEndPoint + " 没有对应的Steam ID映射");
+                    }
+                }
+                
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError("[Patch_SendTo] 异常: " + ex);
+                return true;
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
1. 公众大厅

2. STEAMP2P混合

3. STEAMP2P虚拟网络

### 虚拟网络P2P

-  协议: Steam ISteamNetworking P2P API

- 虚拟IP段: 10.255.0.0/16

- Socket劫持 + IP映射

- 投票系统 netManager.SendToAll() 广播

### 混合P2P (统一LAN和Steam P2P的接口)

 - 协议: Steam ISteamNetworkingSockets API

 - Steam P2P直连 + 中继

 - EndPoint映射: SteamID  127.0.0.1:动态端口

### P2P架构

 - Patch_Socket (Socket劫持层)：拦截标准.NET Socket调用

- SteamEndPointMapper (虚拟IP映射器)：管理SteamID和虚拟IP的双向映射

-  SteamP2PManager (P2P数据包管理)：处理Steam P2P数据包的发送和接收

### PacketSignature (数据包签名)

 - 识别LiteNetLib数据包类型

 - 将LiteNetLib的传输模式映射到Steam P2P

### 虚拟通道

 - 通道0: Unreliable（位置、动画等高频数据）

 - 通道1: Reliable（事件）

 - 通道2: ReliableWithBuffering（大数据块）

 - 通道3: UnreliableNoDelay（实时数据）

### NAT穿透握手

 -  映射时自动发送握手包

 -  SteamNetworking.SendP2PPacket() 建立P2P会话

 -  P2PSessionRequest_t 回调

### 命名规范

  - 公开成员：PascalCase

  - 私有成员：camelCase

  - 常量：UPPER_SNAKE_CASE

### 玩家列表

 - 虚拟网络模式不显示延迟（Steam内部管理）

 - 颜色区分：房主（黄色）、自己（青色）、其他（绿色）

 - 过滤不兼容的MOD版本

### 已知问题

- 虚拟网络P2P/投票面板未同步

- 混合P2P/服务端正常/客户端有明显的同步问题

- 投票面板未同步(混合P2P/虚拟网络P2P)都有

- 虚拟网络P2P：房间名字异常

- MonoMod.Backports.dll没有做依赖引用（未解决之前需要将MonoMod.Backports.dll放进Managed）

### 后续维护

 - 混合P2P(fakePeerCache 用于NetPeer对象管)