### PR TITLE
混合P2P传输层：投票系统RPC框架：RPC框架

### DIFF
--- a/EscapeFromDuckovCoopMod/AnimParamInterpolator .cs
+++ b/EscapeFromDuckovCoopMod/AnimParamInterpolator .cs
@@ -30,13 +30,15 @@ public struct AnimSample
 public class AnimParamInterpolator : MonoBehaviour
 {
     [Header("时间窗")] //不用注释了这都看不懂的话就 nim
-    public float interpolationBackTime = 0.12f;
+    public float interpolationBackTime = 0.08f;
 
-    public float maxExtrapolate = 0.08f;
+    public float maxExtrapolate = 0.06f;
 
-    [Header("平滑")] public float paramSmoothTime = 0.07f;
+    [Header("平滑")] public float paramSmoothTime = 0.05f;
 
-    public float minHoldTime = 0.08f;
+    public float minHoldTime = 0.03f;
+    
+    public float handStateMinHoldTime = 0.01f;
 
     [Header("状态过渡（可选）")] public float crossfadeDuration = 0.05f;
 
@@ -122,7 +124,7 @@ public class AnimParamInterpolator : MonoBehaviour
         var now = Time.unscaledTimeAsDouble;
 
         var desiredHand = t01 < 0.5f ? a.hand : b.hand;
-        if (desiredHand != lastHand && now - tHand >= minHoldTime)
+        if (desiredHand != lastHand && now - tHand >= handStateMinHoldTime)
         {
             TrySetInt(hHand, desiredHand);
             lastHand = desiredHand;
@@ -161,7 +163,8 @@ public class AnimParamInterpolator : MonoBehaviour
             desiredNorm = t01 < 0.5f ? a.normTime : b.normTime;
             if (desiredState >= 0 && (desiredState != lastStateHash || now - tState > 0.5))
             {
-                anim.CrossFade(desiredState, crossfadeDuration, crossfadeLayer, Mathf.Clamp01(desiredNorm));
+                int layerIndex = Mathf.Max(0, crossfadeLayer);
+                anim.CrossFade(desiredState, crossfadeDuration, layerIndex, Mathf.Clamp01(desiredNorm));
                 lastStateHash = desiredState;
                 tState = now;
             }

--- a/EscapeFromDuckovCoopMod/BuildInfo.cs
+++ b/EscapeFromDuckovCoopMod/BuildInfo.cs
@@ -5,5 +5,5 @@ internal static class BuildInfo
     internal const string Name = "EscapeFromDuckovCoopMod";
     internal const string Copyright = "Copyright ?  2025";
     internal const string ModVersion = "1.5.0";
-    internal const string GitCommit = "c60c504";
+    internal const string GitCommit = "e7f94c5";
 }

--- a/EscapeFromDuckovCoopMod/Main/Loader/Loader.cs
+++ b/EscapeFromDuckovCoopMod/Main/Loader/Loader.cs
@@ -42,6 +42,7 @@ public class ModBehaviour : Duckov.Modding.ModBehaviour
         DontDestroyOnLoad(go);
 
         go.AddComponent<SteamP2PLoader>();
+        go.AddComponent<EscapeFromDuckovCoopMod.Net.HybridP2P.HybridP2PRelay>();
         go.AddComponent<AIRequest>();
         go.AddComponent<Send_ClientStatus>();
         go.AddComponent<HealthM>();
@@ -51,6 +52,7 @@ public class ModBehaviour : Duckov.Modding.ModBehaviour
         go.AddComponent<DeadLootBox>();
         go.AddComponent<LootManager>();
         go.AddComponent<SceneNet>();
+        go.AddComponent<VoteSystemRPC>();
         go.AddComponent<MModUI>();
         CoopTool.Init();
 

--- a/EscapeFromDuckovCoopMod/Main/LocalPlayer/LocalPlayerManager.cs
+++ b/EscapeFromDuckovCoopMod/Main/LocalPlayer/LocalPlayerManager.cs
@@ -462,4 +462,6 @@ public class PlayerStatus
     public string CustomFaceJson { get; set; }
     public List<EquipmentSyncData> EquipmentList { get; set; } = new();
     public List<WeaponSyncData> WeaponList { get; set; } = new();
+    public EscapeFromDuckovCoopMod.Net.HybridP2P.NATType NATType { get; set; } = EscapeFromDuckovCoopMod.Net.HybridP2P.NATType.Unknown;
+    public bool UseRelay { get; set; }
 }

--- a/EscapeFromDuckovCoopMod/Main/Localization/LocalizationManager.cs
+++ b/EscapeFromDuckovCoopMod/Main/Localization/LocalizationManager.cs
@@ -272,8 +272,12 @@ namespace EscapeFromDuckovCoopMod
             currentTranslations["ui.playerStatus.toggle"] = "Show Player Status Window (Toggle key: {0})";
             currentTranslations["ui.playerStatus.id"] = "ID:";
             currentTranslations["ui.playerStatus.name"] = "Name:";
+            currentTranslations["ui.playerStatus.ping"] = "Ping";
             currentTranslations["ui.playerStatus.latency"] = "Latency:";
             currentTranslations["ui.playerStatus.inGame"] = "In Game:";
+            currentTranslations["ui.playerStatus.inGameStatus"] = "In Game";
+            currentTranslations["ui.playerStatus.idle"] = "Idle";
+            currentTranslations["ui.playerStatus.local"] = "Local";
             currentTranslations["ui.playerStatus.yes"] = "Yes";
             currentTranslations["ui.playerStatus.no"] = "No";
             currentTranslations["ui.debug.printLootBoxes"] = "[Debug] Print all lootboxes in this map";

--- a/EscapeFromDuckovCoopMod/Main/SceneService/LootManager.cs
+++ b/EscapeFromDuckovCoopMod/Main/SceneService/LootManager.cs
@@ -18,7 +18,7 @@ using System.Collections;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Duckov.UI;
-using Duckov.Utilities;
+﻿using Duckov.Utilities;
 using ItemStatsSystem;
 using UnityEngine.SceneManagement;
 using static EscapeFromDuckovCoopMod.LootNet;
@@ -206,18 +206,38 @@ public static class LootboxDetectUtil
     public static bool IsLootboxInventory(Inventory inv)
     {
         if (inv == null) return false;
-        // 排除私有库存（仓库/宠物包）
         if (IsPrivateInventory(inv)) return false;
 
-        var dict = InteractableLootbox.Inventories;
-        if (dict != null)
-            foreach (var kv in dict)
-                if (kv.Value == inv)
-                    return true;
-        var boxes = Object.FindObjectsOfType<InteractableLootbox>(true);
-        foreach (var b in boxes)
-            if (b && b.Inventory == inv)
-                return true;
+        try
+        {
+            if (InteractableLootbox.Inventories != null)
+            {
+                foreach (var kv in InteractableLootbox.Inventories)
+                {
+                    if (kv.Value != null && ReferenceEquals(kv.Value, inv))
+                        return true;
+                }
+            }
+        }
+        catch
+        {
+        }
+        
+        try
+        {
+            var boxes = Object.FindObjectsOfType<InteractableLootbox>(true);
+            if (boxes != null)
+            {
+                foreach (var b in boxes)
+                {
+                    if (b != null && b.Inventory != null && ReferenceEquals(b.Inventory, inv))
+                        return true;
+                }
+            }
+        }
+        catch
+        {
+        }
 
         return false;
     }

--- a/EscapeFromDuckovCoopMod/Main/SceneService/VoteSystemRPC.cs
+++ b/EscapeFromDuckovCoopMod/Main/SceneService/VoteSystemRPC.cs
@@ -1,0 +1,409 @@
+using LiteNetLib;
+using LiteNetLib.Utils;
+using System.Collections.Generic;
+using UnityEngine;
+using Steamworks;
+
+namespace EscapeFromDuckovCoopMod
+{
+    public class VoteSystemRPC : MonoBehaviour
+    {
+        public static VoteSystemRPC Instance { get; private set; }
+
+        private SceneNet _sceneNet;
+        private bool _rpcRegistered = false;
+
+        public bool UseRPCMode { get; set; } = false;
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        private void Start()
+        {
+            _sceneNet = SceneNet.Instance;
+            if (_sceneNet == null)
+            {
+                Debug.LogError("[VoteSystemRPC] SceneNet.Instance is null");
+                return;
+            }
+
+            RegisterRPCs();
+        }
+
+        private void RegisterRPCs()
+        {
+            var rpcManager = Net.HybridP2P.HybridRPCManager.Instance;
+            if (rpcManager == null)
+            {
+                Debug.LogWarning("[VoteSystemRPC] HybridRPCManager not found, RPC mode disabled");
+                return;
+            }
+
+            rpcManager.RegisterRPC("VoteStart", OnRPC_VoteStart);
+            rpcManager.RegisterRPC("VoteRequest", OnRPC_VoteRequest);
+            rpcManager.RegisterRPC("VoteCast", OnRPC_VoteCast);
+            rpcManager.RegisterRPC("VoteReadySet", OnRPC_VoteReadySet);
+            rpcManager.RegisterRPC("VoteBeginLoad", OnRPC_VoteBeginLoad);
+            rpcManager.RegisterRPC("VoteCancel", OnRPC_VoteCancel);
+
+            _rpcRegistered = true;
+            Debug.Log("[VoteSystemRPC] All RPCs registered");
+        }
+
+        #region Server -> Client RPCs
+
+        public void Server_StartVote(string targetSceneId, string curtainGuid, bool notifyEvac, bool saveToFile, bool useLocation, string locationName, List<ulong> participantSteamIds)
+        {
+            if (!UseRPCMode || !_rpcRegistered)
+            {
+                Debug.Log("[VoteSystemRPC] RPC mode disabled, using legacy method");
+                return;
+            }
+
+            var rpcManager = Net.HybridP2P.HybridRPCManager.Instance;
+            if (rpcManager == null || !rpcManager.IsServer)
+                return;
+
+            string hostSceneId = "";
+            LocalPlayerManager.Instance.ComputeIsInGame(out hostSceneId);
+            hostSceneId = hostSceneId ?? string.Empty;
+
+            rpcManager.CallRPC("VoteStart", Net.HybridP2P.RPCTarget.AllClients, 0, (writer) =>
+            {
+                writer.Put(targetSceneId ?? "");
+                writer.Put(curtainGuid ?? "");
+                writer.Put(notifyEvac);
+                writer.Put(saveToFile);
+                writer.Put(useLocation);
+                writer.Put(locationName ?? "");
+                writer.Put(hostSceneId);
+
+                writer.Put(participantSteamIds.Count);
+                foreach (var steamId in participantSteamIds)
+                {
+                    writer.Put(steamId);
+                }
+            }, DeliveryMethod.ReliableOrdered);
+
+            Debug.Log($"[VoteSystemRPC] Server sent vote start: target={targetSceneId}, participants={participantSteamIds.Count}");
+        }
+
+        public void Server_BroadcastReadySet(string pid, bool ready)
+        {
+            if (!UseRPCMode || !_rpcRegistered)
+                return;
+
+            var rpcManager = Net.HybridP2P.HybridRPCManager.Instance;
+            if (rpcManager == null || !rpcManager.IsServer)
+                return;
+
+            rpcManager.CallRPC("VoteReadySet", Net.HybridP2P.RPCTarget.AllClients, 0, (writer) =>
+            {
+                writer.Put(pid);
+                writer.Put(ready);
+            }, DeliveryMethod.ReliableOrdered);
+
+            Debug.Log($"[VoteSystemRPC] Server broadcast ready: pid={pid}, ready={ready}");
+        }
+
+        public void Server_BroadcastBeginLoad()
+        {
+            if (!UseRPCMode || !_rpcRegistered)
+                return;
+
+            var rpcManager = Net.HybridP2P.HybridRPCManager.Instance;
+            if (rpcManager == null || !rpcManager.IsServer)
+                return;
+
+            rpcManager.CallRPC("VoteBeginLoad", Net.HybridP2P.RPCTarget.AllClients, 0, (writer) =>
+            {
+                writer.Put(_sceneNet.sceneTargetId ?? "");
+                writer.Put(_sceneNet.sceneCurtainGuid ?? "");
+                writer.Put(_sceneNet.sceneNotifyEvac);
+                writer.Put(_sceneNet.sceneSaveToFile);
+                writer.Put(_sceneNet.sceneUseLocation);
+                writer.Put(_sceneNet.sceneLocationName ?? "");
+            }, DeliveryMethod.ReliableOrdered);
+
+            Debug.Log($"[VoteSystemRPC] Server broadcast begin load: target={_sceneNet.sceneTargetId}");
+        }
+
+        public void Server_BroadcastCancelVote()
+        {
+            if (!UseRPCMode || !_rpcRegistered)
+                return;
+
+            var rpcManager = Net.HybridP2P.HybridRPCManager.Instance;
+            if (rpcManager == null || !rpcManager.IsServer)
+                return;
+
+            rpcManager.CallRPC("VoteCancel", Net.HybridP2P.RPCTarget.AllClients, 0, (writer) =>
+            {
+                // No additional data needed
+            }, DeliveryMethod.ReliableOrdered);
+
+            Debug.Log($"[VoteSystemRPC] Server broadcast cancel vote");
+        }
+
+        #endregion
+
+        #region Client -> Server RPCs
+
+        public void Client_RequestVote(string targetId, string curtainGuid, bool notifyEvac, bool saveToFile, bool useLocation, string locationName)
+        {
+            if (!UseRPCMode || !_rpcRegistered)
+                return;
+
+            var rpcManager = Net.HybridP2P.HybridRPCManager.Instance;
+            if (rpcManager == null || rpcManager.IsServer)
+                return;
+
+            rpcManager.CallRPC("VoteRequest", Net.HybridP2P.RPCTarget.Server, 0, (writer) =>
+            {
+                writer.Put(targetId ?? "");
+                writer.Put(curtainGuid ?? "");
+                writer.Put(notifyEvac);
+                writer.Put(saveToFile);
+                writer.Put(useLocation);
+                writer.Put(locationName ?? "");
+            }, DeliveryMethod.ReliableOrdered);
+
+            Debug.Log($"[VoteSystemRPC] Client sent vote request: target={targetId}");
+        }
+
+        public void Client_SendReady(bool ready)
+        {
+            if (!UseRPCMode || !_rpcRegistered)
+                return;
+
+            var rpcManager = Net.HybridP2P.HybridRPCManager.Instance;
+            if (rpcManager == null || rpcManager.IsServer)
+                return;
+
+            rpcManager.CallRPC("VoteCast", Net.HybridP2P.RPCTarget.Server, 0, (writer) =>
+            {
+                writer.Put(ready);
+            }, DeliveryMethod.ReliableOrdered);
+
+            Debug.Log($"[VoteSystemRPC] Client cast vote: ready={ready}");
+        }
+
+        #endregion
+
+        #region RPC Handlers
+
+        private void OnRPC_VoteStart(long senderConnectionId, NetDataReader reader)
+        {
+            if (_sceneNet == null) return;
+
+            string targetSceneId = reader.GetString();
+            string curtainGuid = reader.GetString();
+            bool notifyEvac = reader.GetBool();
+            bool saveToFile = reader.GetBool();
+            bool useLocation = reader.GetBool();
+            string locationName = reader.GetString();
+            string hostSceneId = reader.GetString();
+
+            int participantCount = reader.GetInt();
+            var participantSteamIds = new List<ulong>();
+            for (int i = 0; i < participantCount; i++)
+            {
+                participantSteamIds.Add(reader.GetULong());
+            }
+
+            Debug.Log($"[VoteSystemRPC] Received vote start: target={targetSceneId}, participants={participantCount}");
+
+            _sceneNet.sceneTargetId = targetSceneId;
+            _sceneNet.sceneCurtainGuid = string.IsNullOrEmpty(curtainGuid) ? null : curtainGuid;
+            _sceneNet.sceneNotifyEvac = notifyEvac;
+            _sceneNet.sceneSaveToFile = saveToFile;
+            _sceneNet.sceneUseLocation = useLocation;
+            _sceneNet.sceneLocationName = locationName;
+
+            _sceneNet.sceneParticipantIds.Clear();
+            foreach (var steamId in participantSteamIds)
+            {
+                var pid = $"steam_{steamId}";
+                _sceneNet.sceneParticipantIds.Add(pid);
+            }
+
+            var mySteamId = SteamUser.GetSteamID().m_SteamID;
+            var myPid = $"steam_{mySteamId}";
+
+            if (!string.IsNullOrEmpty(hostSceneId))
+            {
+                string mySceneId = null;
+                LocalPlayerManager.Instance.ComputeIsInGame(out mySceneId);
+                mySceneId = mySceneId ?? string.Empty;
+
+                if (!string.Equals(hostSceneId, mySceneId, System.StringComparison.Ordinal))
+                {
+                    Debug.Log($"[VoteSystemRPC] Different scene: host={hostSceneId}, me={mySceneId}");
+                    return;
+                }
+            }
+
+            if (_sceneNet.sceneParticipantIds.Count > 0 && !_sceneNet.sceneParticipantIds.Contains(myPid))
+            {
+                Debug.LogWarning($"[VoteSystemRPC] Not in participants: me={myPid}");
+                return;
+            }
+
+            _sceneNet.sceneVoteActive = true;
+            _sceneNet.localReady = false;
+            _sceneNet.sceneReady.Clear();
+            foreach (var pid in _sceneNet.sceneParticipantIds)
+            {
+                _sceneNet.sceneReady[pid] = false;
+            }
+
+            Debug.Log($"[VoteSystemRPC] Vote started successfully: participants={_sceneNet.sceneParticipantIds.Count}");
+        }
+
+        private void OnRPC_VoteRequest(long senderConnectionId, NetDataReader reader)
+        {
+            if (_sceneNet == null || !NetService.Instance.IsServer) return;
+
+            string targetId = reader.GetString();
+            string curtainGuid = reader.GetString();
+            bool notifyEvac = reader.GetBool();
+            bool saveToFile = reader.GetBool();
+            bool useLocation = reader.GetBool();
+            string locationName = reader.GetString();
+
+            Debug.Log($"[VoteSystemRPC] Received vote request from {senderConnectionId}: target={targetId}");
+
+            _sceneNet.Host_BeginSceneVote_Simple(targetId, curtainGuid, notifyEvac, saveToFile, useLocation, locationName);
+        }
+
+        private void OnRPC_VoteCast(long senderConnectionId, NetDataReader reader)
+        {
+            if (_sceneNet == null || !NetService.Instance.IsServer) return;
+
+            bool ready = reader.GetBool();
+
+            Debug.Log($"[VoteSystemRPC] Received vote cast from {senderConnectionId}: ready={ready}");
+
+            if (!SteamManager.Initialized || SteamEndPointMapper.Instance == null)
+                return;
+
+            string pid = null;
+            foreach (var kv in NetService.Instance.playerStatuses)
+            {
+                var peer = kv.Key;
+                if (peer == null) continue;
+
+                var endPoint = peer.EndPoint as System.Net.IPEndPoint;
+                if (endPoint != null && SteamEndPointMapper.Instance.TryGetSteamID(endPoint, out var steamId))
+                {
+                    if ((long)steamId.m_SteamID == senderConnectionId)
+                    {
+                        pid = $"steam_{steamId.m_SteamID}";
+                        break;
+                    }
+                }
+            }
+
+            if (string.IsNullOrEmpty(pid))
+            {
+                Debug.LogWarning($"[VoteSystemRPC] Could not find SteamID for connection {senderConnectionId}");
+                return;
+            }
+
+            if (!_sceneNet.sceneVoteActive || !_sceneNet.sceneReady.ContainsKey(pid))
+            {
+                Debug.LogWarning($"[VoteSystemRPC] Invalid vote state for {pid}");
+                return;
+            }
+
+            _sceneNet.sceneReady[pid] = ready;
+            Server_BroadcastReadySet(pid, ready);
+
+            foreach (var id in _sceneNet.sceneParticipantIds)
+            {
+                if (!_sceneNet.sceneReady.TryGetValue(id, out var r) || !r)
+                    return;
+            }
+
+            Server_BroadcastBeginLoad();
+        }
+
+        private void OnRPC_VoteReadySet(long senderConnectionId, NetDataReader reader)
+        {
+            if (_sceneNet == null) return;
+
+            string pid = reader.GetString();
+            bool ready = reader.GetBool();
+
+            Debug.Log($"[VoteSystemRPC] Received ready set: pid={pid}, ready={ready}");
+
+            if (_sceneNet.sceneReady.ContainsKey(pid))
+            {
+                _sceneNet.sceneReady[pid] = ready;
+            }
+        }
+
+        private void OnRPC_VoteBeginLoad(long senderConnectionId, NetDataReader reader)
+        {
+            if (_sceneNet == null) return;
+
+            string targetSceneId = reader.GetString();
+            string curtainGuid = reader.GetString();
+            bool notifyEvac = reader.GetBool();
+            bool saveToFile = reader.GetBool();
+            bool useLocation = reader.GetBool();
+            string locationName = reader.GetString();
+
+            Debug.Log($"[VoteSystemRPC] Received begin load: target={targetSceneId}");
+
+            _sceneNet.sceneVoteActive = false;
+            _sceneNet.sceneTargetId = targetSceneId;
+            _sceneNet.sceneCurtainGuid = string.IsNullOrEmpty(curtainGuid) ? null : curtainGuid;
+            _sceneNet.sceneNotifyEvac = notifyEvac;
+            _sceneNet.sceneSaveToFile = saveToFile;
+            _sceneNet.sceneUseLocation = useLocation;
+            _sceneNet.sceneLocationName = locationName;
+
+            var loadMethod = typeof(SceneNet).GetMethod("TryPerformSceneLoad_Local", 
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            if (loadMethod != null)
+            {
+                _sceneNet.allowLocalSceneLoad = true;
+                loadMethod.Invoke(_sceneNet, new object[] { targetSceneId, curtainGuid, notifyEvac, saveToFile, useLocation, locationName });
+            }
+
+            _sceneNet.sceneReady.Clear();
+            _sceneNet.localReady = false;
+        }
+
+        private void OnRPC_VoteCancel(long senderConnectionId, NetDataReader reader)
+        {
+            if (_sceneNet == null) return;
+
+            Debug.Log($"[VoteSystemRPC] Received cancel vote");
+
+            _sceneNet.sceneVoteActive = false;
+            _sceneNet.localReady = false;
+            _sceneNet.sceneReady.Clear();
+        }
+
+        #endregion
+
+        private void OnDestroy()
+        {
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Main/UI/MModUI.cs
+++ b/EscapeFromDuckovCoopMod/Main/UI/MModUI.cs
@@ -61,6 +61,8 @@ public class MModUI : MonoBehaviour
     // Steam相关字段
     private readonly List<SteamLobbyManager.LobbyInfo> _steamLobbyInfos = new();
     private readonly HashSet<ulong> _displayedSteamLobbies = new();  // 缓存已显示的房间ID
+    private readonly Dictionary<ulong, Sprite> _steamAvatarCache = new();  // 缓存Steam头像
+    private readonly HashSet<ulong> _steamAvatarLoading = new();  // 正在加载的头像
     private string _steamLobbyName = string.Empty;
     private string _steamLobbyPassword = string.Empty;
     private bool _steamLobbyFriendsOnly;
@@ -233,33 +235,39 @@ public class MModUI : MonoBehaviour
     // 面板动画
     internal IEnumerator AnimatePanel(GameObject panel, bool show)
     {
+        if (panel == null) yield break;
+        
         if (show)
         {
             panel.SetActive(true);
             var canvasGroup = panel.GetComponent<CanvasGroup>() ?? panel.AddComponent<CanvasGroup>();
+            if (canvasGroup == null) yield break;
             canvasGroup.alpha = 0;
 
             float time = 0;
-            while (time < 0.2f)
+            while (time < 0.2f && canvasGroup != null)
             {
                 time += Time.deltaTime;
                 canvasGroup.alpha = Mathf.Lerp(0, 1, time / 0.2f);
                 yield return null;
             }
-            canvasGroup.alpha = 1;
+            if (canvasGroup != null)
+                canvasGroup.alpha = 1;
         }
         else
         {
             var canvasGroup = panel.GetComponent<CanvasGroup>() ?? panel.AddComponent<CanvasGroup>();
+            if (canvasGroup == null) yield break;
 
             float time = 0;
-            while (time < 0.15f)
+            while (time < 0.15f && canvasGroup != null && panel != null)
             {
                 time += Time.deltaTime;
                 canvasGroup.alpha = Mathf.Lerp(1, 0, time / 0.15f);
                 yield return null;
             }
-            panel.SetActive(false);
+            if (panel != null)
+                panel.SetActive(false);
         }
     }
 
@@ -1049,7 +1057,6 @@ public class MModUI : MonoBehaviour
                         displayedEndPoints.Add(status.EndPoint);
                         currentPlayerIds.Add(status.EndPoint);
                         playerStatusesToDisplay.Add(status);
-                        Debug.LogWarning($"[MModUI] 添加无SteamID的玩家: {status.EndPoint}");
                     }
                 }
             }
@@ -1245,6 +1252,55 @@ public class MModUI : MonoBehaviour
 
         var headerRow = CreateHorizontalGroup(entry.transform, "Header");
 
+        // Steam头像（如果有）
+        if (TransportMode == NetworkTransportMode.SteamP2P && SteamManager.Initialized)
+        {
+            ulong steamId = 0;
+            
+            if (isLocal)
+            {
+                steamId = SteamUser.GetSteamID().m_SteamID;
+            }
+            else if (LobbyManager != null && LobbyManager.IsInLobby)
+            {
+                var endPoint = status.EndPoint;
+                if (!string.IsNullOrEmpty(endPoint))
+                {
+                    var parts = endPoint.Split(':');
+                    if (parts.Length == 2 && System.Net.IPAddress.TryParse(parts[0], out var ipAddr) && int.TryParse(parts[1], out var port))
+                    {
+                        var ipEndPoint = new System.Net.IPEndPoint(ipAddr, port);
+                        if (SteamEndPointMapper.Instance != null && SteamEndPointMapper.Instance.TryGetSteamID(ipEndPoint, out var cSteamId))
+                        {
+                            steamId = cSteamId.m_SteamID;
+                        }
+                    }
+                }
+            }
+            
+            if (steamId > 0)
+            {
+                var avatarObj = new GameObject("Avatar");
+                avatarObj.transform.SetParent(headerRow.transform, false);
+                var avatarLayout = avatarObj.AddComponent<LayoutElement>();
+                avatarLayout.preferredWidth = 32;
+                avatarLayout.preferredHeight = 32;
+                var avatarImage = avatarObj.AddComponent<Image>();
+                avatarImage.color = new Color(0.3f, 0.3f, 0.3f, 1f);
+                
+                if (_steamAvatarCache.TryGetValue(steamId, out var cachedSprite))
+                {
+                    avatarImage.sprite = cachedSprite;
+                    avatarImage.color = Color.white;
+                    Debug.Log($"[MModUI] 使用缓存的Steam头像: {steamId}");
+                }
+                else
+                {
+                    StartCoroutine(LoadSteamAvatar(new CSteamID(steamId), avatarImage));
+                }
+            }
+        }
+
         // 状态指示器
         var statusDot = new GameObject("StatusDot");
         statusDot.transform.SetParent(headerRow.transform, false);
@@ -1338,15 +1394,47 @@ public class MModUI : MonoBehaviour
 
         CreateDivider(entry.transform);
 
-        var infoRow = CreateHorizontalGroup(entry.transform, "Info");
-        CreateText("ID", infoRow.transform, CoopLocalization.Get("ui.playerStatus.id") + ": " + displayId, 13, ModernColors.TextSecondary);
-
-        var pingText = CreateText("Ping", infoRow.transform, $"{status.Latency}ms", 13,
+        var infoRow1 = CreateHorizontalGroup(entry.transform, "InfoRow1");
+        CreateText("Ping", infoRow1.transform, $"{CoopLocalization.Get("ui.playerStatus.ping")}: {status.Latency}ms", 13,
             status.Latency < 50 ? ModernColors.Success :
             status.Latency < 100 ? ModernColors.Warning : ModernColors.Error);
 
-        var stateText = CreateText("State", infoRow.transform, status.IsInGame ? CoopLocalization.Get("ui.playerStatus.inGameStatus") : CoopLocalization.Get("ui.playerStatus.idle"), 13,
+        CreateText("State", infoRow1.transform, status.IsInGame ? CoopLocalization.Get("ui.playerStatus.inGameStatus") : CoopLocalization.Get("ui.playerStatus.idle"), 13,
             status.IsInGame ? ModernColors.Success : ModernColors.TextSecondary);
+        
+        var relay = EscapeFromDuckovCoopMod.Net.HybridP2P.HybridP2PRelay.Instance;
+        if (relay != null)
+        {
+            EscapeFromDuckovCoopMod.Net.HybridP2P.NATType natType;
+            bool useRelay;
+            
+            if (isLocal)
+            {
+                natType = relay.GetLocalNATType();
+                useRelay = false;
+            }
+            else
+            {
+                natType = status.NATType;
+                useRelay = status.UseRelay;
+            }
+            
+            if (natType != EscapeFromDuckovCoopMod.Net.HybridP2P.NATType.Unknown)
+            {
+                string natTypeText = EscapeFromDuckovCoopMod.Net.HybridP2P.NATDetector.GetNATTypeDisplayName(natType);
+                Color natColor = EscapeFromDuckovCoopMod.Net.HybridP2P.NATDetector.GetNATTypeColor(natType);
+                
+                if (useRelay)
+                {
+                    natTypeText += " (Relay)";
+                }
+                
+                CreateText("NAT", infoRow1.transform, $"NAT: {natTypeText}", 13, natColor);
+            }
+        }
+        
+        var infoRow2 = CreateHorizontalGroup(entry.transform, "InfoRow2");
+        CreateText("ID", infoRow2.transform, CoopLocalization.Get("ui.playerStatus.id") + ": " + displayId, 12, ModernColors.TextSecondary);
     }
 
     private void UpdateVotePanel()
@@ -1357,6 +1445,18 @@ public class MModUI : MonoBehaviour
             {
                 StartCoroutine(AnimatePanel(_components.VotePanel, false));
                 _lastVoteActive = false;
+            }
+            return;
+        }
+        
+        bool inLobby = (LobbyManager != null && LobbyManager.IsInLobby) || (NetService.Instance != null && NetService.Instance.networkStarted);
+        if (!inLobby)
+        {
+            if (_components?.VotePanel != null && _components.VotePanel.activeSelf)
+            {
+                StartCoroutine(AnimatePanel(_components.VotePanel, false));
+                _lastVoteActive = false;
+                Debug.Log("[MModUI] 玩家已离开房间，隐藏投票面板");
             }
             return;
         }
@@ -1480,6 +1580,11 @@ public class MModUI : MonoBehaviour
         listTitleLayout.preferredWidth = -1;
 
         // 玩家列表
+        Debug.Log($"[VOTE-UI] 开始渲染玩家列表, participants={SceneNet.Instance.sceneParticipantIds.Count}, IsServer={IsServer}");
+        
+        // 根据SteamID去重
+        var processedSteamIds = new HashSet<ulong>();
+        
         foreach (var pid in SceneNet.Instance.sceneParticipantIds)
         {
             SceneNet.Instance.sceneReady.TryGetValue(pid, out var ready);
@@ -1494,11 +1599,29 @@ public class MModUI : MonoBehaviour
             // 获取玩家显示名称和ID
             string displayName = pid;
             string displayId = pid;
+            bool isLocalPlayer = false;
 
             if (TransportMode == NetworkTransportMode.SteamP2P && SteamManager.Initialized && LobbyManager != null && LobbyManager.IsInLobby)
             {
-                // Steam模式：pid 可能是 EndPoint 格式（Host:9050, Client:xxx）或 SteamID
+                // Steam模式：pid 可能是 EndPoint 格式（Host:9050, Client:xxx）、SteamID 或 steam_xxxxx 格式
                 ulong steamIdValue = 0;
+                
+                // v3格式：steam_xxxxx
+                if (pid.StartsWith("steam_"))
+                {
+                    var steamIdStr = pid.Substring(6);
+                    if (ulong.TryParse(steamIdStr, out steamIdValue) && steamIdValue > 0)
+                    {
+                        Debug.Log($"[VOTE-UI] v3格式解析成功: {pid} -> SteamID {steamIdValue}");
+                    }
+                    else
+                    {
+                        Debug.LogWarning($"[VOTE-UI] v3格式解析失败: {pid}");
+                    }
+                }
+                // 旧格式处理
+                else
+                {
 
                 // 先尝试直接解析为 SteamID
                 if (ulong.TryParse(pid, out steamIdValue) && steamIdValue > 0)
@@ -1561,9 +1684,44 @@ public class MModUI : MonoBehaviour
                                 SteamEndPointMapper.Instance.TryGetSteamID(ipEndPoint, out CSteamID cSteamId))
                             {
                                 steamIdValue = cSteamId.m_SteamID;
+                                Debug.Log($"[VOTE-UI] IP地址映射成功: {pid} -> SteamID {steamIdValue}");
+                            }
+                            else
+                            {
+                                Debug.LogWarning($"[VOTE-UI] IP地址映射失败: {pid}");
+                                
+                                // 客户端模式：如果映射失败，检查是否是自己的EndPoint
+                                if (!IsServer && ModBehaviourF.Instance?.connectedPeer != null)
+                                {
+                                    var myEndPoint = ModBehaviourF.Instance.connectedPeer.EndPoint?.ToString();
+                                    if (!string.IsNullOrEmpty(myEndPoint) && myEndPoint == pid)
+                                    {
+                                        steamIdValue = SteamUser.GetSteamID().m_SteamID;
+                                        Debug.Log($"[VOTE-UI] 通过connectedPeer.EndPoint识别为本地玩家: {pid} -> SteamID {steamIdValue}");
+                                    }
+                                }
                             }
                         }
                     }
+                }
+                } // 闭合v3格式的else块
+
+                // 判断是否是本地玩家
+                var localSteamId = SteamUser.GetSteamID().m_SteamID;
+                isLocalPlayer = (steamIdValue == localSteamId);
+                Debug.Log($"[VOTE-UI] pid={pid}, steamIdValue={steamIdValue}, localSteamId={localSteamId}, isLocal={isLocalPlayer}");
+
+                // 去重检查：如果SteamID已处理，销毁重复的playerRow并跳过
+                if (steamIdValue > 0 && processedSteamIds.Contains(steamIdValue))
+                {
+                    Debug.Log($"[VOTE-UI] 跳过重复玩家: pid={pid}, steamIdValue={steamIdValue}");
+                    Destroy(playerRow);
+                    continue;
+                }
+                
+                if (steamIdValue > 0)
+                {
+                    processedSteamIds.Add(steamIdValue);
                 }
 
                 // 如果成功获取到 SteamID，显示用户名
@@ -1577,7 +1735,16 @@ public class MModUI : MonoBehaviour
                         // 判断是否是主机
                         var lobbyOwner = SteamMatchmaking.GetLobbyOwner(LobbyManager.CurrentLobbyId);
                         string prefix = (steamIdValue == lobbyOwner.m_SteamID) ? "HOST" : "CLIENT";
-                        displayName = $"{prefix}_{cachedName}";
+                        
+                        // 如果是本地玩家，添加[本地]标识
+                        if (isLocalPlayer)
+                        {
+                            displayName = $"[本地] {prefix}_{cachedName}";
+                        }
+                        else
+                        {
+                            displayName = $"{prefix}_{cachedName}";
+                        }
                     }
                     else
                     {
@@ -1587,7 +1754,16 @@ public class MModUI : MonoBehaviour
                         {
                             var lobbyOwner = SteamMatchmaking.GetLobbyOwner(LobbyManager.CurrentLobbyId);
                             string prefix = (steamIdValue == lobbyOwner.m_SteamID) ? "HOST" : "CLIENT";
-                            displayName = $"{prefix}_{steamUsername}";
+                            
+                            // 如果是本地玩家，添加[本地]标识
+                            if (isLocalPlayer)
+                            {
+                                displayName = $"[本地] {prefix}_{steamUsername}";
+                            }
+                            else
+                            {
+                                displayName = $"{prefix}_{steamUsername}";
+                            }
                         }
                         else
                         {
@@ -1600,7 +1776,8 @@ public class MModUI : MonoBehaviour
             }
 
             // 显示名称和ID
-            var nameText = CreateText("Name", playerRow.transform, displayName, 14, ModernColors.TextPrimary);
+            Debug.Log($"[VOTE-UI] 渲染玩家: pid={pid}, displayName={displayName}, isLocal={isLocalPlayer}");
+            var nameText = CreateText("Name", playerRow.transform, displayName, 14, isLocalPlayer ? ModernColors.Success : ModernColors.TextPrimary);
             var nameLayout = nameText.gameObject.GetComponent<LayoutElement>();
             nameLayout.flexibleWidth = 1;
 
@@ -1645,6 +1822,93 @@ public class MModUI : MonoBehaviour
                     StartCoroutine(AnimatePanel(_components.SpectatorPanel, false));
             }
         }
+    }
+
+    #endregion
+
+    #region 断开连接弹窗
+
+    private GameObject _disconnectDialog;
+
+    public void ShowDisconnectDialog(string reason)
+    {
+        if (_disconnectDialog != null)
+        {
+            Destroy(_disconnectDialog);
+        }
+
+        _disconnectDialog = CreateModernPanel("DisconnectDialog", _canvas.transform, new Vector2(500, 250), new Vector2(960, 100), TextAnchor.LowerCenter);
+        
+        var dialogGroup = _disconnectDialog.GetComponent<CanvasGroup>();
+        if (dialogGroup == null) dialogGroup = _disconnectDialog.AddComponent<CanvasGroup>();
+        dialogGroup.alpha = 0f;
+        
+        var headerRow = CreateHorizontalGroup(_disconnectDialog.transform, "Header");
+        var headerLayout = headerRow.AddComponent<LayoutElement>();
+        headerLayout.minHeight = 50;
+        headerLayout.preferredHeight = 50;
+        
+        var titleText = CreateText("Title", headerRow.transform, "连接已断开", 20, ModernColors.Error, TextAlignmentOptions.Center, FontStyles.Bold);
+        var titleLayout = titleText.gameObject.GetComponent<LayoutElement>();
+        titleLayout.flexibleWidth = 1;
+        
+        CreateDivider(_disconnectDialog.transform);
+        
+        var contentRow = new GameObject("Content");
+        contentRow.transform.SetParent(_disconnectDialog.transform, false);
+        var contentLayout = contentRow.AddComponent<LayoutElement>();
+        contentLayout.flexibleHeight = 1;
+        
+        var reasonText = CreateText("Reason", contentRow.transform, reason, 16, ModernColors.TextPrimary, TextAlignmentOptions.Center);
+        
+        CreateDivider(_disconnectDialog.transform);
+        
+        var buttonRow = CreateHorizontalGroup(_disconnectDialog.transform, "ButtonRow");
+        var buttonLayout = buttonRow.AddComponent<LayoutElement>();
+        buttonLayout.minHeight = 60;
+        buttonLayout.preferredHeight = 60;
+        
+        var okButtonGO = new GameObject("OKButton");
+        okButtonGO.transform.SetParent(buttonRow.transform, false);
+        var okRect = okButtonGO.AddComponent<RectTransform>();
+        var okLayout = okButtonGO.AddComponent<LayoutElement>();
+        okLayout.flexibleWidth = 1;
+        okLayout.minHeight = 40;
+        
+        var okImage = okButtonGO.AddComponent<Image>();
+        okImage.color = ModernColors.Primary;
+        
+        var okButton = okButtonGO.AddComponent<Button>();
+        okButton.onClick.AddListener(() => 
+        {
+            if (_disconnectDialog != null)
+            {
+                Destroy(_disconnectDialog);
+                _disconnectDialog = null;
+            }
+        });
+        
+        CreateText("ButtonText", okButtonGO.transform, "确定", 16, Color.white, TextAlignmentOptions.Center, FontStyles.Bold);
+        
+        StartCoroutine(AnimateDialog(dialogGroup));
+    }
+    
+    private IEnumerator AnimateDialog(CanvasGroup group)
+    {
+        if (group == null) yield break;
+        
+        float duration = 0.3f;
+        float elapsed = 0f;
+        
+        while (elapsed < duration && group != null)
+        {
+            elapsed += Time.deltaTime;
+            group.alpha = Mathf.Lerp(0f, 1f, elapsed / duration);
+            yield return null;
+        }
+        
+        if (group != null)
+            group.alpha = 1f;
     }
 
     #endregion
@@ -1718,6 +1982,93 @@ public class MModUI : MonoBehaviour
         return panel;
     }
 
+    private IEnumerator LoadSteamAvatar(CSteamID steamID, Image targetImage)
+    {
+        if (!SteamManager.Initialized || targetImage == null)
+        {
+            Debug.LogWarning($"[MModUI] LoadSteamAvatar 取消: SteamManager={SteamManager.Initialized}, targetImage={targetImage != null}");
+            yield break;
+        }
+        
+        ulong steamId = steamID.m_SteamID;
+        
+        if (_steamAvatarLoading.Contains(steamId))
+        {
+            yield break;
+        }
+        
+        _steamAvatarLoading.Add(steamId);
+        
+        try
+        {
+            int avatarHandle = SteamFriends.GetMediumFriendAvatar(steamID);
+            Debug.Log($"[MModUI] LoadSteamAvatar for {steamId}: handle={avatarHandle}");
+            
+            if (avatarHandle == -1)
+            {
+                yield return new WaitForSeconds(0.5f);
+                avatarHandle = SteamFriends.GetMediumFriendAvatar(steamID);
+                Debug.Log($"[MModUI] LoadSteamAvatar 重试 for {steamId}: handle={avatarHandle}");
+            }
+            
+            if (avatarHandle > 0)
+            {
+                uint width, height;
+                if (SteamUtils.GetImageSize(avatarHandle, out width, out height))
+                {
+                    Debug.Log($"[MModUI] Steam头像尺寸: {width}x{height}");
+                    if (width > 0 && height > 0)
+                    {
+                        byte[] imageData = new byte[width * height * 4];
+                        if (SteamUtils.GetImageRGBA(avatarHandle, imageData, (int)(width * height * 4)))
+                        {
+                            Texture2D texture = new Texture2D((int)width, (int)height, TextureFormat.RGBA32, false);
+                            texture.LoadRawTextureData(imageData);
+                            texture.Apply();
+                            
+                            for (int y = 0; y < height / 2; y++)
+                            {
+                                for (int x = 0; x < width; x++)
+                                {
+                                    Color temp = texture.GetPixel(x, y);
+                                    texture.SetPixel(x, y, texture.GetPixel(x, (int)height - 1 - y));
+                                    texture.SetPixel(x, (int)height - 1 - y, temp);
+                                }
+                            }
+                            texture.Apply();
+                            
+                            Sprite sprite = Sprite.Create(texture, new Rect(0, 0, width, height), new Vector2(0.5f, 0.5f));
+                            _steamAvatarCache[steamId] = sprite;
+                            
+                            if (targetImage != null)
+                            {
+                                targetImage.sprite = sprite;
+                                targetImage.color = Color.white;
+                            }
+                            Debug.Log($"[MModUI] Steam头像加载成功并缓存: {steamId}");
+                        }
+                        else
+                        {
+                            Debug.LogWarning($"[MModUI] GetImageRGBA 失败: {steamId}");
+                        }
+                    }
+                }
+                else
+                {
+                    Debug.LogWarning($"[MModUI] GetImageSize 失败: {steamId}");
+                }
+            }
+            else if (avatarHandle == 0)
+            {
+                Debug.LogWarning($"[MModUI] Steam头像未准备好: {steamId}");
+            }
+        }
+        finally
+        {
+            _steamAvatarLoading.Remove(steamId);
+        }
+    }
+    
     private IEnumerator InitializeTranslucentImageProperties(TranslucentImage translucentImage)
     {
         // 等待几帧，让 TranslucentImage 完成初始化

--- a/EscapeFromDuckovCoopMod/Main/WeatherAndTime/Weather.cs
+++ b/EscapeFromDuckovCoopMod/Main/WeatherAndTime/Weather.cs
@@ -32,6 +32,18 @@ public class Weather
     private PlayerStatus localPlayerStatus => Service?.localPlayerStatus;
 
     private bool networkStarted => Service != null && Service.networkStarted;
+    
+    private static FieldInfo GetFieldSafe(Type type, string fieldName)
+    {
+        try
+        {
+            return type.GetField(fieldName, System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic);
+        }
+        catch
+        {
+            return null;
+        }
+    }
 
     // ========== 环境同步：主机广播 ==========
     public void Server_BroadcastEnvSync(NetPeer target = null)
@@ -62,7 +74,11 @@ public class Weather
         {
             try
             {
-                seed = (int)AccessTools.Field(wm.GetType(), "seed").GetValue(wm);
+                var seedField = GetFieldSafe(wm.GetType(), "seed");
+                if (seedField != null)
+                {
+                    seed = (int)seedField.GetValue(wm);
+                }
             }
             catch
             {
@@ -70,7 +86,11 @@ public class Weather
 
             try
             {
-                forceWeather = (bool)AccessTools.Field(wm.GetType(), "forceWeather").GetValue(wm);
+                var forceWeatherField = GetFieldSafe(wm.GetType(), "forceWeather");
+                if (forceWeatherField != null)
+                {
+                    forceWeather = (bool)forceWeatherField.GetValue(wm);
+                }
             }
             catch
             {
@@ -78,7 +98,11 @@ public class Weather
 
             try
             {
-                forceWeatherVal = (int)AccessTools.Field(wm.GetType(), "forceWeatherValue").GetValue(wm);
+                var forceWeatherValField = GetFieldSafe(wm.GetType(), "forceWeatherValue");
+                if (forceWeatherValField != null)
+                {
+                    forceWeatherVal = (int)forceWeatherValField.GetValue(wm);
+                }
             }
             catch
             {
@@ -153,7 +177,11 @@ public class Weather
                 var k = 0;
                 try
                 {
-                    k = (int)AccessTools.Field(typeof(global::Door), "doorClosedDataKeyCached").GetValue(d);
+                    var doorField = GetFieldSafe(typeof(global::Door), "doorClosedDataKeyCached");
+                    if (doorField != null)
+                    {
+                        k = (int)doorField.GetValue(d);
+                    }
                 }
                 catch
                 {
@@ -213,8 +241,8 @@ public class Weather
             var inst = GameClock.Instance;
             if (inst != null)
             {
-                AccessTools.Field(inst.GetType(), "days")?.SetValue(inst, day);
-                AccessTools.Field(inst.GetType(), "secondsOfDay")?.SetValue(inst, secOfDay);
+                GetFieldSafe(inst.GetType(), "days")?.SetValue(inst, day);
+                GetFieldSafe(inst.GetType(), "secondsOfDay")?.SetValue(inst, secOfDay);
                 try
                 {
                     inst.clockTimeScale = timeScale;
@@ -237,10 +265,10 @@ public class Weather
             var wm = WeatherManager.Instance;
             if (wm != null && seed != -1)
             {
-                AccessTools.Field(wm.GetType(), "seed")?.SetValue(wm, seed); // 写 seed :contentReference[oaicite:11]{index=11}
+                GetFieldSafe(wm.GetType(), "seed")?.SetValue(wm, seed);
                 wm.GetType().GetMethod("SetupModules", BindingFlags.NonPublic | BindingFlags.Instance)
-                    ?.Invoke(wm, null); // 把 seed 带给 Storm/Precipitation :contentReference[oaicite:12]{index=12}
-                AccessTools.Field(wm.GetType(), "_weatherDirty")?.SetValue(wm, true); // 标脏以便下帧重新取 GetWeather
+                    ?.Invoke(wm, null);
+                GetFieldSafe(wm.GetType(), "_weatherDirty")?.SetValue(wm, true);
             }
         }
         catch

--- a/EscapeFromDuckovCoopMod/Net/HybridP2P/HybridP2PRelay.cs
+++ b/EscapeFromDuckovCoopMod/Net/HybridP2P/HybridP2PRelay.cs
@@ -1,0 +1,332 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using Steamworks;
+using LiteNetLib.Utils;
+
+namespace EscapeFromDuckovCoopMod.Net.HybridP2P;
+
+public class HybridP2PRelay : MonoBehaviour
+{
+    public static HybridP2PRelay Instance { get; private set; }
+    
+    private class RelayConnection
+    {
+        public string EndPoint;
+        public CSteamID SteamID;
+        public NATType NATType;
+        public bool UseRelay;
+        public float LastActivityTime;
+        public int FailedPackets;
+        public bool P2PHealthy = true;
+    }
+    
+    private readonly Dictionary<string, RelayConnection> _connections = new();
+    private HybridP2PValidator _validator;
+    private NATDetector _natDetector;
+    private LatencyCalculator _latencyCalculator;
+    private LatencyCompensator _latencyCompensator;
+    private SteamNetworkingTransport _steamTransport;
+    private HybridRPCManager _rpcManager;
+    
+    public SteamNetworkingTransport SteamTransport => _steamTransport;
+    public HybridRPCManager RPCManager => _rpcManager;
+    public bool UseSteamNetworkingSockets { get; set; } = false;
+    
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+        
+        _validator = new HybridP2PValidator();
+        _natDetector = new NATDetector();
+        _latencyCalculator = new LatencyCalculator();
+        _latencyCompensator = new LatencyCompensator();
+        
+        InitializeSteamNetworking();
+        
+        Debug.Log("[HybridP2PRelay] Initialized");
+    }
+    
+    private void InitializeSteamNetworking()
+    {
+        var transportGO = new GameObject("SteamNetworkingTransport");
+        transportGO.transform.SetParent(transform);
+        _steamTransport = transportGO.AddComponent<SteamNetworkingTransport>();
+        
+        var rpcGO = new GameObject("HybridRPCManager");
+        rpcGO.transform.SetParent(transform);
+        _rpcManager = rpcGO.AddComponent<HybridRPCManager>();
+        _rpcManager.Initialize(_steamTransport);
+        
+        Debug.Log("[HybridP2PRelay] Steam Networking initialized");
+    }
+    
+    private void Start()
+    {
+        InitializeNATDetection();
+    }
+    
+    private void Update()
+    {
+        _latencyCalculator?.Update();
+        CleanupInactiveConnections();
+        CheckP2PHealth();
+    }
+    
+    private async void InitializeNATDetection()
+    {
+        try
+        {
+            var natType = await _natDetector.DetectNATType();
+            Debug.Log($"[HybridP2PRelay] Local NAT type: {NATDetector.GetNATTypeDisplayName(natType)}");
+            
+            var netService = EscapeFromDuckovCoopMod.NetService.Instance;
+            if (netService != null && netService.localPlayerStatus != null)
+            {
+                netService.localPlayerStatus.NATType = natType;
+                netService.localPlayerStatus.UseRelay = !_natDetector.CanDirectConnect(natType);
+                Debug.Log($"[HybridP2PRelay] 更新本地玩家NAT状态: {NATDetector.GetNATTypeDisplayName(natType)}, UseRelay={netService.localPlayerStatus.UseRelay}");
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"[HybridP2PRelay] Error detecting NAT: {e.Message}");
+        }
+    }
+    
+    public void RegisterConnection(string endPoint, CSteamID steamID, NATType natType)
+    {
+        if (!_connections.ContainsKey(endPoint))
+        {
+            bool useRelay = !_natDetector.CanDirectConnect(natType);
+            
+            _connections[endPoint] = new RelayConnection
+            {
+                EndPoint = endPoint,
+                SteamID = steamID,
+                NATType = natType,
+                UseRelay = useRelay,
+                LastActivityTime = Time.realtimeSinceStartup,
+                P2PHealthy = true
+            };
+            
+            _latencyCalculator.RegisterClient(endPoint);
+            
+            var service = EscapeFromDuckovCoopMod.NetService.Instance;
+            var isServer = service?.IsServer ?? false;
+            Debug.Log($"[HybridP2PRelay] 注册连接 endPoint={endPoint}, NAT={NATDetector.GetNATTypeDisplayName(natType)}, Relay={useRelay}, IsServer={isServer}");
+        }
+    }
+    
+    public void UnregisterConnection(string endPoint)
+    {
+        if (_connections.Remove(endPoint))
+        {
+            _latencyCalculator.UnregisterClient(endPoint);
+            Debug.Log($"[HybridP2PRelay] Unregistered connection {endPoint}");
+        }
+    }
+    
+    public bool ValidateAndRelayPacket(string endPoint, NetDataReader reader, byte packetType)
+    {
+        if (!_connections.TryGetValue(endPoint, out var connection))
+        {
+            if (packetType == 19 || packetType == 20 || packetType == 21 || packetType == 23)
+            {
+                Debug.Log($"[HybridP2PRelay] 投票相关消息通过 (未注册连接): endPoint={endPoint}, op={packetType}");
+            }
+            return true;
+        }
+        
+        connection.LastActivityTime = Time.realtimeSinceStartup;
+        
+        if (connection.UseRelay)
+        {
+            Debug.Log($"[HybridP2PRelay] 使用Relay转发: endPoint={endPoint}, op={packetType}");
+            return RelayPacketViaSteam(connection, reader, packetType);
+        }
+        
+        if (packetType == 19 || packetType == 20 || packetType == 21 || packetType == 23)
+        {
+            Debug.Log($"[HybridP2PRelay] 投票相关消息通过: endPoint={endPoint}, op={packetType}");
+        }
+        return true;
+    }
+    
+    private bool ValidatePacket(string endPoint, NetDataReader reader, byte packetType)
+    {
+        try
+        {
+            switch (packetType)
+            {
+                case 1:
+                    var position = new Vector3(reader.GetFloat(), reader.GetFloat(), reader.GetFloat());
+                    var velocity = new Vector3(reader.GetFloat(), reader.GetFloat(), reader.GetFloat());
+                    return _validator.ValidatePositionUpdate(endPoint, position, velocity);
+                
+                case 10:
+                    return _validator.ValidateFireEvent(endPoint);
+                
+                case 11:
+                    float damage = reader.GetFloat();
+                    return _validator.ValidateDamageValue(endPoint, damage);
+                
+                case 200:
+                    _latencyCalculator.HandlePingPacket(endPoint, reader);
+                    return true;
+                
+                case 201:
+                    _latencyCalculator.HandlePongPacket(endPoint, reader);
+                    return true;
+                
+                default:
+                    return true;
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"[HybridP2PRelay] Error validating packet: {e.Message}");
+            return false;
+        }
+    }
+    
+    private bool RelayPacketViaSteam(RelayConnection connection, NetDataReader reader, byte packetType)
+    {
+        try
+        {
+            if (!SteamManager.Initialized)
+            {
+                Debug.LogWarning("[HybridP2PRelay] Steam not initialized, cannot relay");
+                return false;
+            }
+            
+            byte[] data = new byte[reader.AvailableBytes];
+            reader.GetBytes(data, reader.AvailableBytes);
+            
+            bool sent = SteamNetworking.SendP2PPacket(connection.SteamID, data, (uint)data.Length, EP2PSend.k_EP2PSendReliable, 0);
+            
+            if (!sent)
+            {
+                Debug.LogWarning($"[HybridP2PRelay] Failed to relay packet to {connection.EndPoint}");
+            }
+            
+            return sent;
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"[HybridP2PRelay] Error relaying packet: {e.Message}");
+            return false;
+        }
+    }
+    
+    private void CheckP2PHealth()
+    {
+        foreach (var kvp in _connections)
+        {
+            var connection = kvp.Value;
+            
+            if (!connection.P2PHealthy && Time.realtimeSinceStartup - connection.LastActivityTime > 5f)
+            {
+                connection.P2PHealthy = true;
+                connection.UseRelay = !_natDetector.CanDirectConnect(connection.NATType);
+                connection.FailedPackets = 0;
+                Debug.Log($"[HybridP2PRelay] P2P recovered for {connection.EndPoint}");
+            }
+        }
+    }
+    
+    private void CleanupInactiveConnections()
+    {
+        float currentTime = Time.realtimeSinceStartup;
+        List<string> toRemove = new List<string>();
+        
+        foreach (var kvp in _connections)
+        {
+            if (currentTime - kvp.Value.LastActivityTime > 30f)
+            {
+                toRemove.Add(kvp.Key);
+            }
+        }
+        
+        foreach (var endPoint in toRemove)
+        {
+            UnregisterConnection(endPoint);
+        }
+    }
+    
+    public NATType GetConnectionNATType(string endPoint)
+    {
+        if (_connections.TryGetValue(endPoint, out var connection))
+        {
+            return connection.NATType;
+        }
+        return NATType.Unknown;
+    }
+    
+    public bool IsUsingRelay(string endPoint)
+    {
+        if (_connections.TryGetValue(endPoint, out var connection))
+        {
+            return connection.UseRelay;
+        }
+        return false;
+    }
+    
+    public bool IsP2PHealthy(string endPoint)
+    {
+        if (_connections.TryGetValue(endPoint, out var connection))
+        {
+            return connection.P2PHealthy;
+        }
+        return true;
+    }
+    
+    public float GetLatency(string endPoint)
+    {
+        return _latencyCalculator.GetLatency(endPoint);
+    }
+    
+    public NATType GetLocalNATType()
+    {
+        return _natDetector.LocalNATType;
+    }
+    
+    public bool ShouldUseHybridForVote()
+    {
+        int unhealthyCount = 0;
+        int totalCount = 0;
+        
+        foreach (var kvp in _connections)
+        {
+            totalCount++;
+            if (!kvp.Value.P2PHealthy)
+            {
+                unhealthyCount++;
+            }
+        }
+        
+        if (totalCount == 0) return false;
+        
+        float unhealthyRatio = (float)unhealthyCount / totalCount;
+        return unhealthyRatio > 0.3f;
+    }
+    
+    public void RecordPosition(string endPoint, Vector3 position, Quaternion rotation, Vector3 velocity)
+    {
+        _latencyCompensator?.RecordPosition(endPoint, position, rotation, velocity);
+    }
+    
+    public Vector3 CompensatePosition(string endPoint, Vector3 receivedPosition)
+    {
+        float latency = GetLatency(endPoint);
+        return _latencyCompensator?.CompensatePosition(endPoint, receivedPosition, latency) ?? receivedPosition;
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/HybridP2P/HybridP2PValidator.cs
+++ b/EscapeFromDuckovCoopMod/Net/HybridP2P/HybridP2PValidator.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using LiteNetLib.Utils;
+
+namespace EscapeFromDuckovCoopMod.Net.HybridP2P;
+
+public class HybridP2PValidator
+{
+    public static HybridP2PValidator Instance { get; private set; }
+    
+    private class ClientValidationData
+    {
+        public Vector3 LastPosition;
+        public float LastPositionTime;
+        public int SuspiciousCount;
+        public float LastFireTime;
+        public int FireCount;
+        public float FireWindowStart;
+    }
+    
+    private readonly Dictionary<string, ClientValidationData> _clientData = new();
+    private const float MAX_SPEED = 20f;
+    private const float MAX_FIRE_RATE = 20f;
+    private const float FIRE_RATE_WINDOW = 1f;
+    private const int MAX_SUSPICIOUS_COUNT = 10;
+    
+    public HybridP2PValidator()
+    {
+        Instance = this;
+    }
+    
+    public bool ValidatePositionUpdate(string endPoint, Vector3 position, Vector3 velocity)
+    {
+        if (!_clientData.TryGetValue(endPoint, out var data))
+        {
+            data = new ClientValidationData
+            {
+                LastPosition = position,
+                LastPositionTime = Time.realtimeSinceStartup
+            };
+            _clientData[endPoint] = data;
+            return true;
+        }
+        
+        float deltaTime = Time.realtimeSinceStartup - data.LastPositionTime;
+        if (deltaTime < 0.001f) return true;
+        
+        float distance = Vector3.Distance(position, data.LastPosition);
+        float speed = distance / deltaTime;
+        
+        if (speed > MAX_SPEED)
+        {
+            data.SuspiciousCount++;
+            Debug.LogWarning($"[HybridP2PValidator] Suspicious speed detected from {endPoint}: {speed:F2} m/s");
+            
+            if (data.SuspiciousCount >= MAX_SUSPICIOUS_COUNT)
+            {
+                Debug.LogError($"[HybridP2PValidator] Client {endPoint} exceeded suspicious behavior threshold, rejecting");
+                return false;
+            }
+            
+            return false;
+        }
+        
+        data.LastPosition = position;
+        data.LastPositionTime = Time.realtimeSinceStartup;
+        return true;
+    }
+    
+    public bool ValidateFireEvent(string endPoint)
+    {
+        if (!_clientData.TryGetValue(endPoint, out var data))
+        {
+            data = new ClientValidationData
+            {
+                FireWindowStart = Time.realtimeSinceStartup,
+                FireCount = 1,
+                LastFireTime = Time.realtimeSinceStartup
+            };
+            _clientData[endPoint] = data;
+            return true;
+        }
+        
+        float currentTime = Time.realtimeSinceStartup;
+        
+        if (currentTime - data.FireWindowStart > FIRE_RATE_WINDOW)
+        {
+            data.FireWindowStart = currentTime;
+            data.FireCount = 1;
+        }
+        else
+        {
+            data.FireCount++;
+        }
+        
+        if (data.FireCount > MAX_FIRE_RATE)
+        {
+            data.SuspiciousCount++;
+            Debug.LogWarning($"[HybridP2PValidator] Suspicious fire rate from {endPoint}: {data.FireCount} shots in {FIRE_RATE_WINDOW}s");
+            
+            if (data.SuspiciousCount >= MAX_SUSPICIOUS_COUNT)
+            {
+                Debug.LogError($"[HybridP2PValidator] Client {endPoint} exceeded suspicious behavior threshold, rejecting");
+                KickClient(endPoint);
+                return false;
+            }
+            
+            return false;
+        }
+        
+        data.LastFireTime = currentTime;
+        return true;
+    }
+    
+    public bool ValidateDamageValue(string endPoint, float damage)
+    {
+        if (damage < 0 || damage > 1000f)
+        {
+            if (!_clientData.TryGetValue(endPoint, out var data))
+            {
+                data = new ClientValidationData();
+                _clientData[endPoint] = data;
+            }
+            
+            data.SuspiciousCount++;
+            Debug.LogWarning($"[HybridP2PValidator] Invalid damage value from {endPoint}: {damage}");
+            
+            if (data.SuspiciousCount >= MAX_SUSPICIOUS_COUNT)
+            {
+                Debug.LogError($"[HybridP2PValidator] Client {endPoint} exceeded suspicious behavior threshold, rejecting");
+                KickClient(endPoint);
+                return false;
+            }
+            
+            return false;
+        }
+        
+        return true;
+    }
+    
+    public void ResetClientData(string endPoint)
+    {
+        _clientData.Remove(endPoint);
+    }
+    
+    private void KickClient(string endPoint)
+    {
+        try
+        {
+            var service = NetService.Instance;
+            if (service != null && service.IsServer)
+            {
+                var peer = service.netManager?.GetPeerById(0);
+                if (peer != null)
+                {
+                    service.netManager.DisconnectPeer(peer);
+                    Debug.Log($"[HybridP2PValidator] Kicked client {endPoint}");
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"[HybridP2PValidator] Error kicking client: {e.Message}");
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/HybridP2P/HybridRPCExample.cs
+++ b/EscapeFromDuckovCoopMod/Net/HybridP2P/HybridRPCExample.cs
@@ -1,0 +1,94 @@
+using LiteNetLib;
+using LiteNetLib.Utils;
+using UnityEngine;
+
+namespace EscapeFromDuckovCoopMod.Net.HybridP2P
+{
+    public class HybridRPCExample : MonoBehaviour
+    {
+        private void Start()
+        {
+            RegisterExampleRPCs();
+        }
+
+        private void RegisterExampleRPCs()
+        {
+            var rpcManager = HybridRPCManager.Instance;
+            if (rpcManager == null)
+            {
+                Debug.LogWarning("[HybridRPCExample] RPC Manager not found");
+                return;
+            }
+
+            rpcManager.RegisterRPC("TestRPC", HandleTestRPC);
+            rpcManager.RegisterRPC("SyncVoteData", HandleSyncVoteData);
+            rpcManager.RegisterRPC("RequestPlayerData", HandleRequestPlayerData);
+            
+            Debug.Log("[HybridRPCExample] Example RPCs registered");
+        }
+
+        private void HandleTestRPC(long senderConnectionId, NetDataReader reader)
+        {
+            string message = reader.GetString();
+            int value = reader.GetInt();
+            
+            Debug.Log($"[HybridRPCExample] Received TestRPC from {senderConnectionId}: message='{message}', value={value}");
+        }
+
+        private void HandleSyncVoteData(long senderConnectionId, NetDataReader reader)
+        {
+            string voteId = reader.GetString();
+            int voteCount = reader.GetInt();
+            bool isReady = reader.GetBool();
+            
+            Debug.Log($"[HybridRPCExample] Received SyncVoteData from {senderConnectionId}: voteId='{voteId}', count={voteCount}, ready={isReady}");
+        }
+
+        private void HandleRequestPlayerData(long senderConnectionId, NetDataReader reader)
+        {
+            ulong playerId = reader.GetULong();
+            
+            Debug.Log($"[HybridRPCExample] Received RequestPlayerData from {senderConnectionId}: playerId={playerId}");
+            
+            var rpcManager = HybridRPCManager.Instance;
+            if (rpcManager != null && rpcManager.IsServer)
+            {
+                rpcManager.CallRPC("SendPlayerDataResponse", RPCTarget.TargetClient, senderConnectionId, (writer) =>
+                {
+                    writer.Put(playerId);
+                    writer.Put("PlayerName");
+                    writer.Put(100);
+                    writer.Put(75.5f);
+                });
+            }
+        }
+
+        public static void CallTestRPC(string message, int value)
+        {
+            var rpcManager = HybridRPCManager.Instance;
+            if (rpcManager == null)
+                return;
+
+            rpcManager.CallRPC("TestRPC", RPCTarget.Server, 0, (writer) =>
+            {
+                writer.Put(message);
+                writer.Put(value);
+            });
+        }
+
+        public static void BroadcastVoteData(string voteId, int voteCount, bool isReady)
+        {
+            var rpcManager = HybridRPCManager.Instance;
+            if (rpcManager == null || !rpcManager.IsServer)
+                return;
+
+            rpcManager.CallRPC("SyncVoteData", RPCTarget.AllClients, 0, (writer) =>
+            {
+                writer.Put(voteId);
+                writer.Put(voteCount);
+                writer.Put(isReady);
+            });
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/HybridP2P/HybridRPCManager.cs
+++ b/EscapeFromDuckovCoopMod/Net/HybridP2P/HybridRPCManager.cs
@@ -1,0 +1,520 @@
+using LiteNetLib;
+using LiteNetLib.Utils;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace EscapeFromDuckovCoopMod.Net.HybridP2P
+{
+    public enum RPCTarget : byte
+    {
+        Server = 0,
+        AllClients = 1,
+        TargetClient = 2,
+        AllClientsExceptSender = 3
+    }
+
+    public delegate void RPCHandler(long senderConnectionId, NetDataReader reader);
+
+    public enum TransportMode
+    {
+        Auto,    // 自动选择（优先Steam）
+        Steam,   // 强制使用Steam
+        LAN      // 强制使用LAN
+    }
+
+    public class HybridRPCManager : MonoBehaviour
+    {
+        private const byte RPC_MESSAGE_TYPE = 255;
+
+        private readonly Dictionary<ushort, RPCHandler> _rpcHandlers = new Dictionary<ushort, RPCHandler>();
+        private readonly Dictionary<string, ushort> _rpcNameToId = new Dictionary<string, ushort>();
+        private readonly Dictionary<ushort, string> _rpcIdToName = new Dictionary<ushort, string>();
+        
+        private SteamNetworkingTransport _steamTransport;
+        private ushort _nextRpcId = 1;
+
+        public static HybridRPCManager Instance { get; private set; }
+        public TransportMode Mode { get; set; } = TransportMode.Auto;
+        
+        public bool IsServer
+        {
+            get
+            {
+                if (UseSteamTransport)
+                    return _steamTransport != null && _steamTransport.IsServerStarted;
+                else
+                    return NetService.Instance != null && NetService.Instance.IsServer;
+            }
+        }
+        
+        public bool IsClient
+        {
+            get
+            {
+                if (UseSteamTransport)
+                    return _steamTransport != null && _steamTransport.IsClientStarted;
+                else
+                    return NetService.Instance != null && !NetService.Instance.IsServer;
+            }
+        }
+        
+        private bool UseSteamTransport
+        {
+            get
+            {
+                if (Mode == TransportMode.Steam) return true;
+                if (Mode == TransportMode.LAN) return false;
+                
+                // Auto模式：如果Steam传输层可用且已启动，使用Steam
+                return _steamTransport != null && 
+                       (_steamTransport.IsServerStarted || _steamTransport.IsClientStarted);
+            }
+        }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            
+            Debug.Log("[HybridRPCManager] 初始化完成");
+        }
+
+        public void Initialize(SteamNetworkingTransport transport)
+        {
+            _steamTransport = transport;
+            Debug.Log("[HybridRPCManager] 已绑定Steam传输层");
+        }
+
+        public ushort RegisterRPC(string rpcName, RPCHandler handler)
+        {
+            if (_rpcNameToId.TryGetValue(rpcName, out ushort existingId))
+            {
+                Debug.LogWarning($"[HybridRPCManager] RPC '{rpcName}' already registered with ID {existingId}");
+                return existingId;
+            }
+
+            ushort rpcId = _nextRpcId++;
+            _rpcHandlers[rpcId] = handler;
+            _rpcNameToId[rpcName] = rpcId;
+            _rpcIdToName[rpcId] = rpcName;
+            
+            Debug.Log($"[HybridRPCManager] Registered RPC '{rpcName}' with ID {rpcId}");
+            return rpcId;
+        }
+
+        public void UnregisterRPC(string rpcName)
+        {
+            if (_rpcNameToId.TryGetValue(rpcName, out ushort rpcId))
+            {
+                _rpcHandlers.Remove(rpcId);
+                _rpcNameToId.Remove(rpcName);
+                _rpcIdToName.Remove(rpcId);
+                Debug.Log($"[HybridRPCManager] Unregistered RPC '{rpcName}'");
+            }
+        }
+
+        public void CallRPC(string rpcName, RPCTarget target, long targetConnectionId, Action<NetDataWriter> writeData, DeliveryMethod deliveryMethod = DeliveryMethod.ReliableOrdered)
+        {
+            if (!_rpcNameToId.TryGetValue(rpcName, out ushort rpcId))
+            {
+                Debug.LogError($"[HybridRPCManager] RPC '{rpcName}' not registered");
+                return;
+            }
+
+            NetDataWriter writer = new NetDataWriter();
+            writer.Put(RPC_MESSAGE_TYPE);
+            writer.Put(rpcId);
+            writer.Put((byte)target);
+            
+            if (target == RPCTarget.TargetClient)
+            {
+                writer.Put(targetConnectionId);
+            }
+
+            writeData?.Invoke(writer);
+
+            if (UseSteamTransport)
+            {
+                SendViaSteam(target, targetConnectionId, writer.CopyData(), deliveryMethod);
+            }
+            else
+            {
+                SendViaLAN(target, targetConnectionId, writer, deliveryMethod);
+            }
+        }
+        
+        private void SendViaSteam(RPCTarget target, long targetConnectionId, byte[] data, DeliveryMethod deliveryMethod)
+        {
+            if (_steamTransport == null)
+            {
+                Debug.LogError("[HybridRPCManager] Steam transport not initialized");
+                return;
+            }
+
+            if (IsServer)
+            {
+                SendSteamRPCAsServer(target, targetConnectionId, data, deliveryMethod);
+            }
+            else if (IsClient)
+            {
+                if (target != RPCTarget.Server)
+                {
+                    Debug.LogWarning($"[HybridRPCManager] Client can only call RPCs with target 'Server', got: {target}");
+                    return;
+                }
+                _steamTransport.ClientSend(data, deliveryMethod);
+            }
+        }
+        
+        private void SendViaLAN(RPCTarget target, long targetConnectionId, NetDataWriter writer, DeliveryMethod deliveryMethod)
+        {
+            var netService = NetService.Instance;
+            if (netService == null || netService.netManager == null)
+            {
+                Debug.LogError("[HybridRPCManager] NetService not available");
+                return;
+            }
+
+            if (IsServer)
+            {
+                SendLANRPCAsServer(target, targetConnectionId, writer, deliveryMethod);
+            }
+            else if (IsClient)
+            {
+                if (target != RPCTarget.Server)
+                {
+                    Debug.LogWarning($"[HybridRPCManager] Client can only call RPCs with target 'Server', got: {target}");
+                    return;
+                }
+                
+                if (netService.connectedPeer != null)
+                {
+                    netService.connectedPeer.Send(writer, deliveryMethod);
+                    Debug.Log($"[HybridRPCManager] Sent LAN RPC to server");
+                }
+            }
+        }
+
+        private void SendSteamRPCAsServer(RPCTarget target, long targetConnectionId, byte[] data, DeliveryMethod deliveryMethod)
+        {
+            switch (target)
+            {
+                case RPCTarget.Server:
+                    Debug.LogWarning("[HybridRPCManager] Server cannot call RPC to itself");
+                    break;
+
+                case RPCTarget.AllClients:
+                    foreach (var kvp in GetAllServerConnections())
+                    {
+                        _steamTransport.ServerSend(kvp.Key, data, deliveryMethod);
+                    }
+                    Debug.Log($"[HybridRPCManager] Sent Steam RPC to all {GetAllServerConnections().Count} clients");
+                    break;
+
+                case RPCTarget.TargetClient:
+                    if (_steamTransport.ServerSend(targetConnectionId, data, deliveryMethod))
+                    {
+                        Debug.Log($"[HybridRPCManager] Sent Steam RPC to client {targetConnectionId}");
+                    }
+                    else
+                    {
+                        Debug.LogWarning($"[HybridRPCManager] Failed to send Steam RPC to client {targetConnectionId}");
+                    }
+                    break;
+
+                case RPCTarget.AllClientsExceptSender:
+                    int sentCount = 0;
+                    foreach (var kvp in GetAllServerConnections())
+                    {
+                        if (kvp.Key != targetConnectionId)
+                        {
+                            _steamTransport.ServerSend(kvp.Key, data, deliveryMethod);
+                            sentCount++;
+                        }
+                    }
+                    Debug.Log($"[HybridRPCManager] Sent Steam RPC to {sentCount} clients (excluding sender {targetConnectionId})");
+                    break;
+            }
+        }
+        
+        private void SendLANRPCAsServer(RPCTarget target, long targetConnectionId, NetDataWriter writer, DeliveryMethod deliveryMethod)
+        {
+            var netService = NetService.Instance;
+            if (netService == null || netService.netManager == null)
+                return;
+
+            switch (target)
+            {
+                case RPCTarget.Server:
+                    Debug.LogWarning("[HybridRPCManager] Server cannot call RPC to itself");
+                    break;
+
+                case RPCTarget.AllClients:
+                    netService.netManager.SendToAll(writer, deliveryMethod);
+                    Debug.Log($"[HybridRPCManager] Sent LAN RPC to all {netService.netManager.ConnectedPeersCount} clients");
+                    break;
+
+                case RPCTarget.TargetClient:
+                    // 在LAN模式下，targetConnectionId实际上需要是NetPeer
+                    // 这需要从playerStatuses中查找对应的peer
+                    bool found = false;
+                    foreach (var kvp in netService.playerStatuses)
+                    {
+                        // 暂时使用端口作为ID匹配（需要改进）
+                        var peer = kvp.Key;
+                        if (peer != null)
+                        {
+                            netService.netManager.SendToAll(writer, deliveryMethod); // 临时方案
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found)
+                    {
+                        Debug.LogWarning($"[HybridRPCManager] Failed to find LAN client {targetConnectionId}");
+                    }
+                    break;
+
+                case RPCTarget.AllClientsExceptSender:
+                    netService.netManager.SendToAll(writer, deliveryMethod); // 简化版，暂不排除发送者
+                    Debug.Log($"[HybridRPCManager] Sent LAN RPC to all clients (simplified)");
+                    break;
+            }
+        }
+
+        public void ProcessMessages()
+        {
+            // 只处理Steam模式的消息
+            // LAN模式的消息在Mod.OnNetworkReceive中处理
+            if (!UseSteamTransport)
+                return;
+
+            if (_steamTransport == null)
+                return;
+
+            if (IsServer)
+            {
+                ProcessServerMessages();
+            }
+
+            if (IsClient)
+            {
+                ProcessClientMessages();
+            }
+        }
+        
+        // 供Mod.OnNetworkReceive调用，处理LAN模式的RPC消息
+        public void ProcessLANMessage(long senderConnectionId, NetPacketReader reader)
+        {
+            if (reader == null || reader.AvailableBytes < 3)
+                return;
+
+            byte messageType = reader.GetByte();
+            if (messageType != RPC_MESSAGE_TYPE)
+                return;
+
+            ushort rpcId = reader.GetUShort();
+            RPCTarget target = (RPCTarget)reader.GetByte();
+
+            NetDataReader dataReader = new NetDataReader(reader.RawData, reader.Position, reader.AvailableBytes);
+
+            if (IsServer && target != RPCTarget.Server)
+            {
+                // 服务器转发消息
+                ForwardLANMessage(target, senderConnectionId, rpcId, dataReader);
+                return;
+            }
+
+            if (_rpcHandlers.TryGetValue(rpcId, out RPCHandler handler))
+            {
+                string rpcName = _rpcIdToName.TryGetValue(rpcId, out string name) ? name : $"RPC_{rpcId}";
+                Debug.Log($"[HybridRPCManager] Invoking LAN RPC '{rpcName}' from {senderConnectionId}");
+                handler?.Invoke(senderConnectionId, dataReader);
+            }
+            else
+            {
+                Debug.LogWarning($"[HybridRPCManager] No handler for LAN RPC ID {rpcId}");
+            }
+        }
+        
+        private void ForwardLANMessage(RPCTarget target, long senderConnectionId, ushort rpcId, NetDataReader dataReader)
+        {
+            var netService = NetService.Instance;
+            if (netService == null || netService.netManager == null)
+                return;
+
+            NetDataWriter writer = new NetDataWriter();
+            writer.Put(RPC_MESSAGE_TYPE);
+            writer.Put(rpcId);
+            writer.Put((byte)target);
+            
+            // 复制剩余数据
+            int remainingBytes = dataReader.AvailableBytes;
+            if (remainingBytes > 0)
+            {
+                byte[] data = new byte[remainingBytes];
+                dataReader.GetBytes(data, remainingBytes);
+                writer.Put(data);
+            }
+
+            netService.netManager.SendToAll(writer, DeliveryMethod.ReliableOrdered);
+            Debug.Log($"[HybridRPCManager] Forwarded LAN RPC {rpcId} from {senderConnectionId}");
+        }
+
+        private void ProcessServerMessages()
+        {
+            while (_steamTransport.ServerReceive(out NetworkEventData eventData))
+            {
+                switch (eventData.Type)
+                {
+                    case NetworkEventType.Data:
+                        HandleRPCMessage(eventData.ConnectionId, eventData.Data);
+                        break;
+
+                    case NetworkEventType.Connect:
+                        Debug.Log($"[HybridRPCManager] Steam client connected: {eventData.ConnectionId}");
+                        break;
+
+                    case NetworkEventType.Disconnect:
+                        Debug.Log($"[HybridRPCManager] Steam client disconnected: {eventData.ConnectionId}, reason: {eventData.DisconnectReason}");
+                        break;
+
+                    case NetworkEventType.Error:
+                        Debug.LogError($"[HybridRPCManager] Steam server error: {eventData.ErrorMessage}");
+                        break;
+                }
+            }
+        }
+
+        private void ProcessClientMessages()
+        {
+            while (_steamTransport.ClientReceive(out NetworkEventData eventData))
+            {
+                switch (eventData.Type)
+                {
+                    case NetworkEventType.Data:
+                        HandleRPCMessage(eventData.ConnectionId, eventData.Data);
+                        break;
+
+                    case NetworkEventType.Connect:
+                        Debug.Log($"[HybridRPCManager] Connected to Steam server: {eventData.ConnectionId}");
+                        break;
+
+                    case NetworkEventType.Disconnect:
+                        Debug.Log($"[HybridRPCManager] Disconnected from Steam server: {eventData.ConnectionId}, reason: {eventData.DisconnectReason}");
+                        break;
+
+                    case NetworkEventType.Error:
+                        Debug.LogError($"[HybridRPCManager] Steam client error: {eventData.ErrorMessage}");
+                        break;
+                }
+            }
+        }
+
+        private void HandleRPCMessage(long senderConnectionId, byte[] data)
+        {
+            if (data == null || data.Length < 3)
+            {
+                Debug.LogWarning("[HybridRPCManager] Received invalid RPC message");
+                return;
+            }
+
+            try
+            {
+                NetDataReader reader = new NetDataReader(data);
+                byte messageType = reader.GetByte();
+
+                if (messageType != RPC_MESSAGE_TYPE)
+                {
+                    Debug.LogWarning($"[HybridRPCManager] Invalid message type: {messageType}");
+                    return;
+                }
+
+                ushort rpcId = reader.GetUShort();
+                RPCTarget target = (RPCTarget)reader.GetByte();
+
+                if (IsServer && target != RPCTarget.Server)
+                {
+                    long targetConnectionId = -1;
+                    if (target == RPCTarget.TargetClient || target == RPCTarget.AllClientsExceptSender)
+                    {
+                        targetConnectionId = reader.GetLong();
+                    }
+
+                    NetDataWriter writer = new NetDataWriter();
+                    writer.Put(RPC_MESSAGE_TYPE);
+                    writer.Put(rpcId);
+                    writer.Put((byte)target);
+                    
+                    int remainingBytes = reader.AvailableBytes;
+                    if (remainingBytes > 0)
+                    {
+                        byte[] remainingData = new byte[remainingBytes];
+                        reader.GetBytes(remainingData, remainingBytes);
+                        writer.Put(remainingData);
+                    }
+
+                    byte[] forwardData = writer.CopyData();
+                    SendSteamRPCAsServer(target, senderConnectionId, forwardData, DeliveryMethod.ReliableOrdered);
+                    return;
+                }
+
+                if (_rpcHandlers.TryGetValue(rpcId, out RPCHandler handler))
+                {
+                    string rpcName = _rpcIdToName.TryGetValue(rpcId, out string name) ? name : $"RPC_{rpcId}";
+                    Debug.Log($"[HybridRPCManager] Invoking RPC '{rpcName}' from {senderConnectionId}");
+                    handler?.Invoke(senderConnectionId, reader);
+                }
+                else
+                {
+                    Debug.LogWarning($"[HybridRPCManager] No handler for RPC ID {rpcId}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[HybridRPCManager] Error handling RPC message: {ex.Message}\n{ex.StackTrace}");
+            }
+        }
+
+        private Dictionary<long, object> GetAllServerConnections()
+        {
+            var connections = new Dictionary<long, object>();
+            
+            if (_steamTransport == null || !_steamTransport.IsServerStarted)
+                return connections;
+
+            for (int i = 0; i < _steamTransport.ServerPeersCount; i++)
+            {
+                connections.Add(i, null);
+            }
+
+            return connections;
+        }
+
+        private void Update()
+        {
+            ProcessMessages();
+        }
+
+        private void OnDestroy()
+        {
+            _rpcHandlers.Clear();
+            _rpcNameToId.Clear();
+            _rpcIdToName.Clear();
+
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+
+            Debug.Log("[HybridRPCManager] Destroyed");
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/HybridP2P/LatencyCalculator.cs
+++ b/EscapeFromDuckovCoopMod/Net/HybridP2P/LatencyCalculator.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using LiteNetLib;
+using LiteNetLib.Utils;
+
+namespace EscapeFromDuckovCoopMod.Net.HybridP2P;
+
+public class LatencyCalculator
+{
+    public static LatencyCalculator Instance { get; private set; }
+    
+    private class PingData
+    {
+        public float LastPingTime;
+        public float LastPongTime;
+        public int PingSequence;
+        public Queue<float> LatencySamples = new Queue<float>();
+        public float AverageLatency;
+        public float LastLatency;
+    }
+    
+    private readonly Dictionary<string, PingData> _pingData = new();
+    private const float PING_INTERVAL = 1.0f;
+    private const int MAX_SAMPLES = 10;
+    
+    public LatencyCalculator()
+    {
+        Instance = this;
+    }
+    
+    public void Update()
+    {
+        float currentTime = Time.realtimeSinceStartup;
+        
+        foreach (var kvp in _pingData)
+        {
+            if (currentTime - kvp.Value.LastPingTime >= PING_INTERVAL)
+            {
+                SendPing(kvp.Key);
+            }
+        }
+        
+        if (_updateLogTimer <= 0f)
+        {
+            if (_pingData.Count > 0)
+            {
+                Debug.Log($"[LATENCY-UPDATE] 延迟监控活跃: 已注册{_pingData.Count}个连接");
+                foreach (var kvp in _pingData)
+                {
+                    Debug.Log($"  - {kvp.Key}: avg={kvp.Value.AverageLatency:F1}ms, samples={kvp.Value.LatencySamples.Count}");
+                }
+            }
+            _updateLogTimer = 10f;
+        }
+        else
+        {
+            _updateLogTimer -= Time.deltaTime;
+        }
+    }
+    
+    private float _updateLogTimer = 10f;
+    
+    public void RegisterClient(string endPoint)
+    {
+        if (!_pingData.ContainsKey(endPoint))
+        {
+            _pingData[endPoint] = new PingData
+            {
+                LastPingTime = Time.realtimeSinceStartup - PING_INTERVAL,
+                PingSequence = 0
+            };
+            Debug.Log($"[LATENCY-REG] 注册客户端延迟监控: endPoint={endPoint}");
+        }
+    }
+    
+    public void UnregisterClient(string endPoint)
+    {
+        _pingData.Remove(endPoint);
+    }
+    
+    private void SendPing(string endPoint)
+    {
+        try
+        {
+            var service = NetService.Instance;
+            if (service == null || service.netManager == null)
+            {
+                Debug.LogWarning($"[LATENCY-SEND] NetService不可用");
+                return;
+            }
+            
+            var data = _pingData[endPoint];
+            data.PingSequence++;
+            data.LastPingTime = Time.realtimeSinceStartup;
+            
+            var writer = new NetDataWriter();
+            writer.Put((byte)200);
+            writer.Put(data.PingSequence);
+            writer.Put(data.LastPingTime);
+            
+            var peer = FindPeerByEndPoint(endPoint);
+            if (peer != null)
+            {
+                peer.Send(writer, DeliveryMethod.Unreliable);
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"[LatencyCalculator] Error sending ping: {e.Message}");
+        }
+    }
+    
+    public void HandlePingPacket(string endPoint, NetDataReader reader)
+    {
+        try
+        {
+            int sequence = reader.GetInt();
+            float sendTime = reader.GetFloat();
+            
+            var writer = new NetDataWriter();
+            writer.Put((byte)201);
+            writer.Put(sequence);
+            writer.Put(sendTime);
+            
+            var peer = FindPeerByEndPoint(endPoint);
+            if (peer != null)
+            {
+                peer.Send(writer, DeliveryMethod.Unreliable);
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"[LatencyCalculator] Error handling ping: {e.Message}");
+        }
+    }
+    
+    public void HandlePongPacket(string endPoint, NetDataReader reader)
+    {
+        try
+        {
+            int sequence = reader.GetInt();
+            float sendTime = reader.GetFloat();
+            
+            if (!_pingData.TryGetValue(endPoint, out var data))
+            {
+                return;
+            }
+            
+            if (sequence != data.PingSequence)
+            {
+                return;
+            }
+            
+            float currentTime = Time.realtimeSinceStartup;
+            float latency = (currentTime - sendTime) * 1000f;
+            
+            data.LastLatency = latency;
+            data.LastPongTime = currentTime;
+            
+            data.LatencySamples.Enqueue(latency);
+            if (data.LatencySamples.Count > MAX_SAMPLES)
+            {
+                data.LatencySamples.Dequeue();
+            }
+            
+            float sum = 0;
+            foreach (var sample in data.LatencySamples)
+            {
+                sum += sample;
+            }
+            data.AverageLatency = sum / data.LatencySamples.Count;
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"[LatencyCalculator] Error handling pong: {e.Message}");
+        }
+    }
+    
+    public float GetLatency(string endPoint)
+    {
+        if (_pingData.TryGetValue(endPoint, out var data))
+        {
+            return data.AverageLatency;
+        }
+        return 0f;
+    }
+    
+    public float GetLastLatency(string endPoint)
+    {
+        if (_pingData.TryGetValue(endPoint, out var data))
+        {
+            return data.LastLatency;
+        }
+        return 0f;
+    }
+    
+    private NetPeer FindPeerByEndPoint(string endPoint)
+    {
+        var service = NetService.Instance;
+        if (service == null || service.netManager == null) return null;
+        
+        foreach (var peer in service.netManager.ConnectedPeerList)
+        {
+            if (peer.EndPoint.ToString() == endPoint)
+            {
+                return peer;
+            }
+        }
+        
+        return null;
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/HybridP2P/LatencyCompensator.cs
+++ b/EscapeFromDuckovCoopMod/Net/HybridP2P/LatencyCompensator.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace EscapeFromDuckovCoopMod.Net.HybridP2P
+{
+    public class PositionSnapshot
+    {
+        public Vector3 Position;
+        public Quaternion Rotation;
+        public Vector3 Velocity;
+        public float Timestamp;
+    }
+    
+    public class LatencyCompensator
+    {
+        private Dictionary<string, Queue<PositionSnapshot>> _historyBuffers = new Dictionary<string, Queue<PositionSnapshot>>();
+        private const int MAX_HISTORY_SIZE = 60;
+        private const float MAX_HISTORY_TIME = 2.0f;
+        
+        public void RecordPosition(string endPoint, Vector3 position, Quaternion rotation, Vector3 velocity)
+        {
+            if (!_historyBuffers.ContainsKey(endPoint))
+            {
+                _historyBuffers[endPoint] = new Queue<PositionSnapshot>();
+            }
+            
+            var queue = _historyBuffers[endPoint];
+            var snapshot = new PositionSnapshot
+            {
+                Position = position,
+                Rotation = rotation,
+                Velocity = velocity,
+                Timestamp = Time.realtimeSinceStartup
+            };
+            
+            queue.Enqueue(snapshot);
+            
+            while (queue.Count > MAX_HISTORY_SIZE)
+            {
+                queue.Dequeue();
+            }
+            
+            float currentTime = Time.realtimeSinceStartup;
+            while (queue.Count > 0 && (currentTime - queue.Peek().Timestamp) > MAX_HISTORY_TIME)
+            {
+                queue.Dequeue();
+            }
+        }
+        
+        public Vector3 CompensatePosition(string endPoint, Vector3 receivedPosition, float latencyMs)
+        {
+            if (latencyMs <= 0 || latencyMs > 500f)
+            {
+                return receivedPosition;
+            }
+            
+            if (!_historyBuffers.ContainsKey(endPoint))
+            {
+                return receivedPosition;
+            }
+            
+            var queue = _historyBuffers[endPoint];
+            if (queue.Count < 2)
+            {
+                return receivedPosition;
+            }
+            
+            float latencySec = latencyMs / 1000f;
+            float targetTime = Time.realtimeSinceStartup - latencySec;
+            
+            PositionSnapshot before = null;
+            PositionSnapshot after = null;
+            
+            foreach (var snapshot in queue)
+            {
+                if (snapshot.Timestamp <= targetTime)
+                {
+                    before = snapshot;
+                }
+                else
+                {
+                    after = snapshot;
+                    break;
+                }
+            }
+            
+            if (before == null || after == null)
+            {
+                var last = GetLastSnapshot(endPoint);
+                if (last != null && last.Velocity.sqrMagnitude > 0.01f)
+                {
+                    return last.Position + last.Velocity * latencySec;
+                }
+                return receivedPosition;
+            }
+            
+            float t = Mathf.InverseLerp(before.Timestamp, after.Timestamp, targetTime);
+            Vector3 interpolatedPos = Vector3.Lerp(before.Position, after.Position, t);
+            
+            Vector3 velocity = (after.Position - before.Position) / (after.Timestamp - before.Timestamp);
+            if (velocity.sqrMagnitude > 0.01f)
+            {
+                interpolatedPos += velocity * latencySec * 0.5f;
+            }
+            
+            float maxCompensationDistance = 5f;
+            Vector3 offset = interpolatedPos - receivedPosition;
+            if (offset.sqrMagnitude > maxCompensationDistance * maxCompensationDistance)
+            {
+                offset = offset.normalized * maxCompensationDistance;
+                interpolatedPos = receivedPosition + offset;
+            }
+            
+            return interpolatedPos;
+        }
+        
+        public PositionSnapshot GetLastSnapshot(string endPoint)
+        {
+            if (!_historyBuffers.ContainsKey(endPoint) || _historyBuffers[endPoint].Count == 0)
+            {
+                return null;
+            }
+            
+            PositionSnapshot last = null;
+            foreach (var snapshot in _historyBuffers[endPoint])
+            {
+                last = snapshot;
+            }
+            return last;
+        }
+        
+        public void Clear(string endPoint)
+        {
+            if (_historyBuffers.ContainsKey(endPoint))
+            {
+                _historyBuffers.Remove(endPoint);
+            }
+        }
+        
+        public void ClearAll()
+        {
+            _historyBuffers.Clear();
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/HybridP2P/NATDetector.cs
+++ b/EscapeFromDuckovCoopMod/Net/HybridP2P/NATDetector.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using UnityEngine;
+using Steamworks;
+
+namespace EscapeFromDuckovCoopMod.Net.HybridP2P;
+
+public enum NATType
+{
+    Unknown,
+    Open,
+    Moderate,
+    Strict,
+    Blocked
+}
+
+public class NATDetector
+{
+    public static NATDetector Instance { get; private set; }
+    
+    private NATType _localNATType = NATType.Unknown;
+    private string _publicIP = "";
+    private int _publicPort = 0;
+    
+    public NATType LocalNATType => _localNATType;
+    public string PublicIP => _publicIP;
+    public int PublicPort => _publicPort;
+    
+    public NATDetector()
+    {
+        Instance = this;
+    }
+    
+    public async Task<NATType> DetectNATType()
+    {
+        try
+        {
+            if (SteamManager.Initialized)
+            {
+                var p2pInfo = await GetSteamP2PInfo();
+                _localNATType = p2pInfo;
+                Debug.Log($"[NATDetector] Detected NAT type via Steam: {_localNATType}");
+                return _localNATType;
+            }
+            
+            _localNATType = await DetectNATTypeViaSTUN();
+            Debug.Log($"[NATDetector] Detected NAT type via STUN: {_localNATType}");
+            return _localNATType;
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"[NATDetector] Error detecting NAT type: {e.Message}");
+            _localNATType = NATType.Unknown;
+            return _localNATType;
+        }
+    }
+    
+    private async Task<NATType> GetSteamP2PInfo()
+    {
+        await Task.Delay(100);
+        
+        try
+        {
+            SteamNetworking.AllowP2PPacketRelay(true);
+            
+            return NATType.Moderate;
+        }
+        catch
+        {
+            return NATType.Unknown;
+        }
+    }
+    
+    private async Task<NATType> DetectNATTypeViaSTUN()
+    {
+        try
+        {
+            using (var client = new UdpClient())
+            {
+                var stunServer = "stun.l.google.com";
+                var stunPort = 19302;
+                
+                client.Connect(stunServer, stunPort);
+                
+                byte[] bindingRequest = CreateSTUNBindingRequest();
+                await client.SendAsync(bindingRequest, bindingRequest.Length);
+                
+                var receiveTask = client.ReceiveAsync();
+                var timeoutTask = Task.Delay(3000);
+                
+                var completedTask = await Task.WhenAny(receiveTask, timeoutTask);
+                
+                if (completedTask == timeoutTask)
+                {
+                    Debug.LogWarning("[NATDetector] STUN request timeout");
+                    return NATType.Strict;
+                }
+                
+                var result = receiveTask.Result;
+                var response = result.Buffer;
+                
+                if (ParseSTUNResponse(response, out string mappedIP, out int mappedPort))
+                {
+                    _publicIP = mappedIP;
+                    _publicPort = mappedPort;
+                    
+                    var localEndPoint = client.Client.LocalEndPoint as IPEndPoint;
+                    if (localEndPoint != null)
+                    {
+                        if (localEndPoint.Port == mappedPort)
+                        {
+                            return NATType.Open;
+                        }
+                        else
+                        {
+                            return NATType.Moderate;
+                        }
+                    }
+                }
+                
+                return NATType.Unknown;
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"[NATDetector] STUN detection failed: {e.Message}");
+            return NATType.Unknown;
+        }
+    }
+    
+    private byte[] CreateSTUNBindingRequest()
+    {
+        byte[] request = new byte[20];
+        
+        request[0] = 0x00;
+        request[1] = 0x01;
+        
+        request[2] = 0x00;
+        request[3] = 0x00;
+        
+        request[4] = 0x21;
+        request[5] = 0x12;
+        request[6] = 0xA4;
+        request[7] = 0x42;
+        
+        var random = new System.Random();
+        for (int i = 8; i < 20; i++)
+        {
+            request[i] = (byte)random.Next(256);
+        }
+        
+        return request;
+    }
+    
+    private bool ParseSTUNResponse(byte[] response, out string ip, out int port)
+    {
+        ip = "";
+        port = 0;
+        
+        try
+        {
+            if (response.Length < 20) return false;
+            
+            if (response[0] != 0x01 || response[1] != 0x01) return false;
+            
+            int pos = 20;
+            while (pos < response.Length)
+            {
+                if (pos + 4 > response.Length) break;
+                
+                ushort attrType = (ushort)((response[pos] << 8) | response[pos + 1]);
+                ushort attrLength = (ushort)((response[pos + 2] << 8) | response[pos + 3]);
+                
+                if (attrType == 0x0001 || attrType == 0x0020)
+                {
+                    if (pos + 4 + attrLength > response.Length) break;
+                    
+                    if (attrLength >= 8)
+                    {
+                        byte family = response[pos + 5];
+                        
+                        if (family == 0x01)
+                        {
+                            port = (response[pos + 6] << 8) | response[pos + 7];
+                            
+                            if (attrType == 0x0020)
+                            {
+                                port ^= 0x2112;
+                            }
+                            
+                            byte[] ipBytes = new byte[4];
+                            Array.Copy(response, pos + 8, ipBytes, 0, 4);
+                            
+                            if (attrType == 0x0020)
+                            {
+                                ipBytes[0] ^= 0x21;
+                                ipBytes[1] ^= 0x12;
+                                ipBytes[2] ^= 0xA4;
+                                ipBytes[3] ^= 0x42;
+                            }
+                            
+                            ip = $"{ipBytes[0]}.{ipBytes[1]}.{ipBytes[2]}.{ipBytes[3]}";
+                            return true;
+                        }
+                    }
+                }
+                
+                pos += 4 + attrLength;
+                pos = (pos + 3) & ~3;
+            }
+            
+            return false;
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"[NATDetector] Error parsing STUN response: {e.Message}");
+            return false;
+        }
+    }
+    
+    public static string GetNATTypeDisplayName(NATType type)
+    {
+        return type switch
+        {
+            NATType.Open => "Open",
+            NATType.Moderate => "Moderate",
+            NATType.Strict => "Strict",
+            NATType.Blocked => "Blocked",
+            _ => "Unknown"
+        };
+    }
+    
+    public static Color GetNATTypeColor(NATType type)
+    {
+        return type switch
+        {
+            NATType.Open => new Color(0.3f, 0.8f, 0.3f),
+            NATType.Moderate => new Color(1f, 0.8f, 0.2f),
+            NATType.Strict => new Color(1f, 0.4f, 0.2f),
+            NATType.Blocked => new Color(0.8f, 0.2f, 0.2f),
+            _ => Color.gray
+        };
+    }
+    
+    public bool CanDirectConnect(NATType remoteType)
+    {
+        if (_localNATType == NATType.Open) return true;
+        if (_localNATType == NATType.Moderate && remoteType != NATType.Strict) return true;
+        if (_localNATType == NATType.Strict && remoteType == NATType.Open) return true;
+        
+        return false;
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/HybridP2P/SteamNetworkingTransport.cs
+++ b/EscapeFromDuckovCoopMod/Net/HybridP2P/SteamNetworkingTransport.cs
@@ -1,0 +1,554 @@
+using LiteNetLib;
+using LiteNetLib.Utils;
+using Steamworks;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+namespace EscapeFromDuckovCoopMod.Net.HybridP2P
+{
+    public enum NetworkEventType : byte
+    {
+        Data = 0,
+        Connect = 1,
+        Disconnect = 2,
+        Error = 3
+    }
+
+    public struct NetworkEventData
+    {
+        public NetworkEventType Type;
+        public long ConnectionId;
+        public byte[] Data;
+        public DisconnectReason DisconnectReason;
+        public string ErrorMessage;
+    }
+
+    public class SteamNetworkingTransport : MonoBehaviour
+    {
+        private class SteamConnection
+        {
+            public CSteamID SteamID;
+            public HSteamNetConnection Connection;
+            public long ConnectionId;
+            public bool IsConnected;
+            public float LastMessageTime;
+
+            public SteamConnection(CSteamID steamId, HSteamNetConnection connection, long connectionId)
+            {
+                SteamID = steamId;
+                Connection = connection;
+                ConnectionId = connectionId;
+                IsConnected = false;
+                LastMessageTime = Time.realtimeSinceStartup;
+            }
+        }
+
+        private const int MAX_MESSAGES = 256;
+        private const int MAX_MESSAGE_SIZE = 1024 * 512;
+
+        public bool IsServerStarted { get; private set; }
+        public bool IsClientStarted => _clientConnection != null;
+        public int ServerPeersCount => _serverConnections.Count;
+        public int ServerMaxConnections { get; private set; }
+
+        private HSteamListenSocket _serverSocket;
+        private SteamConnection _clientConnection;
+        private readonly Dictionary<long, SteamConnection> _serverConnections = new Dictionary<long, SteamConnection>();
+        private readonly Queue<NetworkEventData> _clientEventQueue = new Queue<NetworkEventData>();
+        private readonly Queue<NetworkEventData> _serverEventQueue = new Queue<NetworkEventData>();
+        
+        private Callback<SteamNetConnectionStatusChangedCallback_t> _connectionCallback;
+        private SteamNetworkingConfigValue_t[] _connectionConfig;
+
+        public static SteamNetworkingTransport Instance { get; private set; }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+            
+            InitializeConfig();
+            Debug.Log("[SteamNetworkingTransport] 初始化完成");
+        }
+
+        private void InitializeConfig()
+        {
+            _connectionConfig = new SteamNetworkingConfigValue_t[]
+            {
+                new SteamNetworkingConfigValue_t
+                {
+                    m_eValue = ESteamNetworkingConfigValue.k_ESteamNetworkingConfig_TimeoutConnected,
+                    m_eDataType = ESteamNetworkingConfigDataType.k_ESteamNetworkingConfig_Int32,
+                    m_val = new SteamNetworkingConfigValue_t.OptionValue { m_int32 = 10000 }
+                }
+            };
+        }
+
+        public bool StartServer(int port, int maxConnections)
+        {
+            if (IsServerStarted)
+            {
+                Debug.LogWarning("[SteamNetworkingTransport] Server already started");
+                return false;
+            }
+
+            if (!SteamManager.Initialized)
+            {
+                Debug.LogError("[SteamNetworkingTransport] Steam not initialized");
+                return false;
+            }
+
+            try
+            {
+                SteamNetworkingUtils.InitRelayNetworkAccess();
+                
+                if (_connectionCallback == null)
+                {
+                    _connectionCallback = Callback<SteamNetConnectionStatusChangedCallback_t>.Create(OnConnectionStatusChanged);
+                }
+
+                _serverSocket = SteamNetworkingSockets.CreateListenSocketP2P(port, _connectionConfig.Length, _connectionConfig);
+                IsServerStarted = true;
+                ServerMaxConnections = maxConnections;
+                
+                Debug.Log($"[SteamNetworkingTransport] Server started on port {port}, max connections: {maxConnections}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[SteamNetworkingTransport] Failed to start server: {ex.Message}\n{ex.StackTrace}");
+                return false;
+            }
+        }
+
+        public bool StartClient(string address, int port)
+        {
+            if (IsClientStarted)
+            {
+                Debug.LogWarning("[SteamNetworkingTransport] Client already started");
+                return false;
+            }
+
+            if (!SteamManager.Initialized)
+            {
+                Debug.LogError("[SteamNetworkingTransport] Steam not initialized");
+                return false;
+            }
+
+            try
+            {
+                SteamNetworkingUtils.InitRelayNetworkAccess();
+                
+                if (_connectionCallback == null)
+                {
+                    _connectionCallback = Callback<SteamNetConnectionStatusChangedCallback_t>.Create(OnConnectionStatusChanged);
+                }
+
+                if (!ulong.TryParse(address, out ulong steamId))
+                {
+                    Debug.LogError($"[SteamNetworkingTransport] Invalid Steam ID: {address}");
+                    return false;
+                }
+
+                CSteamID targetSteamId = new CSteamID(steamId);
+                SteamNetworkingIdentity identity = new SteamNetworkingIdentity();
+                identity.SetSteamID(targetSteamId);
+
+                HSteamNetConnection connection = SteamNetworkingSockets.ConnectP2P(ref identity, port, _connectionConfig.Length, _connectionConfig);
+                _clientConnection = new SteamConnection(targetSteamId, connection, (long)steamId);
+                
+                Debug.Log($"[SteamNetworkingTransport] Client connecting to {steamId} on port {port}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[SteamNetworkingTransport] Failed to start client: {ex.Message}\n{ex.StackTrace}");
+                return false;
+            }
+        }
+
+        public void StopServer()
+        {
+            if (!IsServerStarted)
+                return;
+
+            foreach (var conn in _serverConnections.Values)
+            {
+                SteamNetworkingSockets.CloseConnection(conn.Connection, 0, "Server stopped", false);
+            }
+
+            _serverConnections.Clear();
+            SteamNetworkingSockets.CloseListenSocket(_serverSocket);
+            IsServerStarted = false;
+
+            if (!IsClientStarted && _connectionCallback != null)
+            {
+                _connectionCallback.Dispose();
+                _connectionCallback = null;
+            }
+
+            Debug.Log("[SteamNetworkingTransport] Server stopped");
+        }
+
+        public void StopClient()
+        {
+            if (!IsClientStarted)
+                return;
+
+            if (_clientConnection != null)
+            {
+                SteamNetworkingSockets.CloseConnection(_clientConnection.Connection, 0, "Client disconnected", false);
+                _clientConnection = null;
+            }
+
+            if (!IsServerStarted && _connectionCallback != null)
+            {
+                _connectionCallback.Dispose();
+                _connectionCallback = null;
+            }
+
+            Debug.Log("[SteamNetworkingTransport] Client stopped");
+        }
+
+        public bool ServerSend(long connectionId, byte[] data, DeliveryMethod deliveryMethod)
+        {
+            if (!IsServerStarted)
+                return false;
+
+            if (!_serverConnections.TryGetValue(connectionId, out var conn))
+            {
+                Debug.LogWarning($"[SteamNetworkingTransport] Connection not found: {connectionId}");
+                return false;
+            }
+
+            return SendMessage(conn.Connection, data, deliveryMethod);
+        }
+
+        public bool ClientSend(byte[] data, DeliveryMethod deliveryMethod)
+        {
+            if (!IsClientStarted || _clientConnection == null)
+                return false;
+
+            return SendMessage(_clientConnection.Connection, data, deliveryMethod);
+        }
+
+        public bool ServerReceive(out NetworkEventData eventData)
+        {
+            eventData = default;
+
+            if (!IsServerStarted)
+                return false;
+
+            foreach (var conn in _serverConnections.Values)
+            {
+                if (conn.IsConnected)
+                {
+                    ReceiveMessages(conn, _serverEventQueue);
+                }
+            }
+
+            if (_serverEventQueue.Count == 0)
+                return false;
+
+            eventData = _serverEventQueue.Dequeue();
+            return true;
+        }
+
+        public bool ClientReceive(out NetworkEventData eventData)
+        {
+            eventData = default;
+
+            if (!IsClientStarted || _clientConnection == null)
+                return false;
+
+            if (_clientConnection.IsConnected)
+            {
+                ReceiveMessages(_clientConnection, _clientEventQueue);
+            }
+
+            if (_clientEventQueue.Count == 0)
+                return false;
+
+            eventData = _clientEventQueue.Dequeue();
+            return true;
+        }
+
+        public bool ServerDisconnect(long connectionId, string reason = "Disconnected")
+        {
+            if (!IsServerStarted)
+                return false;
+
+            if (!_serverConnections.TryGetValue(connectionId, out var conn))
+                return false;
+
+            SteamNetworkingSockets.CloseConnection(conn.Connection, 0, reason, false);
+            _serverConnections.Remove(connectionId);
+            
+            Debug.Log($"[SteamNetworkingTransport] Disconnected: {connectionId}, reason: {reason}");
+            return true;
+        }
+
+        public long GetClientRtt()
+        {
+            if (!IsClientStarted || _clientConnection == null)
+                return 0;
+
+            P2PSessionState_t sessionState;
+            if (SteamNetworking.GetP2PSessionState(_clientConnection.SteamID, out sessionState))
+            {
+                return sessionState.m_nRemoteIP;
+            }
+
+            return 0;
+        }
+
+        public long GetServerRtt(long connectionId)
+        {
+            if (!IsServerStarted)
+                return 0;
+
+            if (!_serverConnections.TryGetValue(connectionId, out var conn))
+                return 0;
+
+            P2PSessionState_t sessionState;
+            if (SteamNetworking.GetP2PSessionState(conn.SteamID, out sessionState))
+            {
+                return sessionState.m_nRemoteIP;
+            }
+
+            return 0;
+        }
+
+        private bool SendMessage(HSteamNetConnection connection, byte[] data, DeliveryMethod deliveryMethod)
+        {
+            if (data == null || data.Length == 0)
+                return false;
+
+            if (data.Length > MAX_MESSAGE_SIZE)
+            {
+                Debug.LogError($"[SteamNetworkingTransport] Message too large: {data.Length} > {MAX_MESSAGE_SIZE}");
+                return false;
+            }
+
+            try
+            {
+                GCHandle pinnedArray = GCHandle.Alloc(data, GCHandleType.Pinned);
+                IntPtr pData = pinnedArray.AddrOfPinnedObject();
+
+                int sendFlags = GetSendFlags(deliveryMethod);
+                EResult result = SteamNetworkingSockets.SendMessageToConnection(connection, pData, (uint)data.Length, sendFlags, out long _);
+
+                pinnedArray.Free();
+
+                if (result == EResult.k_EResultOK)
+                {
+                    return true;
+                }
+                else if (result == EResult.k_EResultNoConnection || result == EResult.k_EResultInvalidParam)
+                {
+                    Debug.LogWarning($"[SteamNetworkingTransport] Connection lost");
+                    SteamNetworkingSockets.CloseConnection(connection, 0, "Connection lost", false);
+                    return false;
+                }
+                else
+                {
+                    Debug.LogError($"[SteamNetworkingTransport] Send failed: {result}");
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[SteamNetworkingTransport] Send exception: {ex.Message}");
+                return false;
+            }
+        }
+
+        private void ReceiveMessages(SteamConnection connection, Queue<NetworkEventData> eventQueue)
+        {
+            try
+            {
+                IntPtr[] ptrs = new IntPtr[MAX_MESSAGES];
+                int messageCount = SteamNetworkingSockets.ReceiveMessagesOnConnection(connection.Connection, ptrs, MAX_MESSAGES);
+
+                if (messageCount > 0)
+                {
+                    connection.LastMessageTime = Time.realtimeSinceStartup;
+
+                    for (int i = 0; i < messageCount; i++)
+                    {
+                        SteamNetworkingMessage_t message = Marshal.PtrToStructure<SteamNetworkingMessage_t>(ptrs[i]);
+
+                        if (message.m_cbSize > 0)
+                        {
+                            byte[] buffer = new byte[message.m_cbSize];
+                            Marshal.Copy(message.m_pData, buffer, 0, message.m_cbSize);
+
+                            eventQueue.Enqueue(new NetworkEventData
+                            {
+                                Type = NetworkEventType.Data,
+                                ConnectionId = connection.ConnectionId,
+                                Data = buffer
+                            });
+                        }
+
+                        SteamNetworkingMessage_t.Release(ptrs[i]);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[SteamNetworkingTransport] Receive exception: {ex.Message}");
+            }
+        }
+
+        private void OnConnectionStatusChanged(SteamNetConnectionStatusChangedCallback_t callback)
+        {
+            CSteamID remoteSteamId = callback.m_info.m_identityRemote.GetSteamID();
+            long connectionId = (long)remoteSteamId.m_SteamID;
+
+            Debug.Log($"[SteamNetworkingTransport] Connection status changed: {remoteSteamId} -> {callback.m_info.m_eState}");
+
+            switch (callback.m_info.m_eState)
+            {
+                case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_Connecting:
+                    if (IsServerStarted)
+                    {
+                        EResult acceptResult = SteamNetworkingSockets.AcceptConnection(callback.m_hConn);
+                        if (acceptResult == EResult.k_EResultOK)
+                        {
+                            var conn = new SteamConnection(remoteSteamId, callback.m_hConn, connectionId);
+                            _serverConnections[connectionId] = conn;
+                            Debug.Log($"[SteamNetworkingTransport] Server accepted connection: {remoteSteamId}");
+                        }
+                        else
+                        {
+                            Debug.LogWarning($"[SteamNetworkingTransport] Failed to accept connection: {remoteSteamId}, result: {acceptResult}");
+                        }
+                    }
+                    break;
+
+                case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_Connected:
+                    if (IsServerStarted && _serverConnections.TryGetValue(connectionId, out var serverConn))
+                    {
+                        serverConn.IsConnected = true;
+                        _serverEventQueue.Enqueue(new NetworkEventData
+                        {
+                            Type = NetworkEventType.Connect,
+                            ConnectionId = connectionId
+                        });
+                        Debug.Log($"[SteamNetworkingTransport] Server connection established: {remoteSteamId}");
+                    }
+                    else if (IsClientStarted && _clientConnection != null && _clientConnection.SteamID == remoteSteamId)
+                    {
+                        _clientConnection.IsConnected = true;
+                        _clientEventQueue.Enqueue(new NetworkEventData
+                        {
+                            Type = NetworkEventType.Connect,
+                            ConnectionId = connectionId
+                        });
+                        Debug.Log($"[SteamNetworkingTransport] Client connection established: {remoteSteamId}");
+                    }
+                    break;
+
+                case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ClosedByPeer:
+                case ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ProblemDetectedLocally:
+                    DisconnectReason reason = callback.m_info.m_eState == ESteamNetworkingConnectionState.k_ESteamNetworkingConnectionState_ClosedByPeer
+                        ? DisconnectReason.DisconnectPeerCalled
+                        : DisconnectReason.ConnectionFailed;
+
+                    if (IsServerStarted && _serverConnections.TryGetValue(connectionId, out var disconnServerConn))
+                    {
+                        _serverEventQueue.Enqueue(new NetworkEventData
+                        {
+                            Type = NetworkEventType.Disconnect,
+                            ConnectionId = connectionId,
+                            DisconnectReason = reason
+                        });
+                        _serverConnections.Remove(connectionId);
+                        SteamNetworkingSockets.CloseConnection(callback.m_hConn, 0, "Disconnected", false);
+                        Debug.Log($"[SteamNetworkingTransport] Server connection closed: {remoteSteamId}, reason: {reason}");
+                    }
+                    else if (IsClientStarted && _clientConnection != null && _clientConnection.SteamID == remoteSteamId)
+                    {
+                        _clientEventQueue.Enqueue(new NetworkEventData
+                        {
+                            Type = NetworkEventType.Disconnect,
+                            ConnectionId = connectionId,
+                            DisconnectReason = reason
+                        });
+                        _clientConnection = null;
+                        Debug.Log($"[SteamNetworkingTransport] Client connection closed: {remoteSteamId}, reason: {reason}");
+                    }
+                    break;
+            }
+        }
+
+        private int GetSendFlags(DeliveryMethod deliveryMethod)
+        {
+            switch (deliveryMethod)
+            {
+                case DeliveryMethod.ReliableOrdered:
+                case DeliveryMethod.ReliableUnordered:
+                case DeliveryMethod.ReliableSequenced:
+                    return Constants.k_nSteamNetworkingSend_Reliable;
+                
+                case DeliveryMethod.Sequenced:
+                    return Constants.k_nSteamNetworkingSend_UnreliableNoNagle;
+                
+                case DeliveryMethod.Unreliable:
+                default:
+                    return Constants.k_nSteamNetworkingSend_Unreliable;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            StopClient();
+            StopServer();
+
+            if (_connectionCallback != null)
+            {
+                _connectionCallback.Dispose();
+                _connectionCallback = null;
+            }
+
+            if (Instance == this)
+            {
+                Instance = null;
+            }
+
+            Debug.Log("[SteamNetworkingTransport] Destroyed");
+        }
+
+        private void Update()
+        {
+            if (IsServerStarted)
+            {
+                var now = Time.realtimeSinceStartup;
+                var toRemove = new List<long>();
+
+                foreach (var kvp in _serverConnections)
+                {
+                    if (now - kvp.Value.LastMessageTime > 30f)
+                    {
+                        Debug.LogWarning($"[SteamNetworkingTransport] Connection timeout: {kvp.Key}");
+                        toRemove.Add(kvp.Key);
+                    }
+                }
+
+                foreach (var connId in toRemove)
+                {
+                    ServerDisconnect(connId, "Timeout");
+                }
+            }
+        }
+    }
+}
+

--- a/EscapeFromDuckovCoopMod/Net/Steam/SteamP2PManager.cs
+++ b/EscapeFromDuckovCoopMod/Net/Steam/SteamP2PManager.cs
@@ -14,7 +14,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
 
-using Steamworks;
+﻿using Steamworks;
 using System.Collections.Concurrent;
 using System.Net;
 

--- a/EscapeFromDuckovCoopMod/Patch/SteamP2P/Patch_Socket.cs
+++ b/EscapeFromDuckovCoopMod/Patch/SteamP2P/Patch_Socket.cs
@@ -106,6 +106,48 @@ namespace EscapeFromDuckovCoopMod
         {
             if (!SteamP2PLoader.Instance.UseSteamP2P || !SteamManager.Initialized)
                 return true;
+            
+            try
+            {
+                if (buffer == null)
+                {
+                    Debug.LogError("[Patch_ReceiveFrom] Buffer is null, returning to original method");
+                    return true;
+                }
+                
+                if (remoteEP == null)
+                {
+                    Debug.LogError("[Patch_ReceiveFrom] RemoteEP is null, returning to original method");
+                    return true;
+                }
+                
+                if (offset < 0)
+                {
+                    Debug.LogError($"[Patch_ReceiveFrom] Invalid offset: {offset}, must be >= 0");
+                    __result = 0;
+                    return false;
+                }
+                
+                if (size <= 0)
+                {
+                    Debug.LogError($"[Patch_ReceiveFrom] Invalid size: {size}, must be > 0");
+                    __result = 0;
+                    return false;
+                }
+                
+                if (offset + size > buffer.Length)
+                {
+                    Debug.LogError($"[Patch_ReceiveFrom] Buffer overflow: offset({offset}) + size({size}) > buffer.Length({buffer.Length})");
+                    __result = 0;
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[Patch_ReceiveFrom] Parameter validation exception: {ex.Message}");
+                return true;
+            }
+            
             try
             {
                 if (SteamP2PManager.Instance != null)

--- a/Localization/en-US.json
+++ b/Localization/en-US.json
@@ -23,6 +23,7 @@
     { "key": "ui.playerStatus.toggle", "value": "Show Player Status Window (Toggle key: {0})" },
     { "key": "ui.playerStatus.id", "value": "ID:" },
     { "key": "ui.playerStatus.name", "value": "Name:" },
+    { "key": "ui.playerStatus.ping", "value": "Ping" },
     { "key": "ui.playerStatus.latency", "value": "Latency:" },
     { "key": "ui.playerStatus.inGame", "value": "In Game:" },
     { "key": "ui.playerStatus.yes", "value": "Yes" },

--- a/Localization/ja-JP.json
+++ b/Localization/ja-JP.json
@@ -23,6 +23,7 @@
     { "key": "ui.playerStatus.toggle", "value": "プレイヤーステータスウィンドウを表示 (トグルキー: {0})" },
     { "key": "ui.playerStatus.id", "value": "ID:" },
     { "key": "ui.playerStatus.name", "value": "名前:" },
+    { "key": "ui.playerStatus.ping", "value": "ピング" },
     { "key": "ui.playerStatus.latency", "value": "遅延:" },
     { "key": "ui.playerStatus.inGame", "value": "ゲーム中:" },
     { "key": "ui.playerStatus.yes", "value": "はい" },

--- a/Localization/ko-KR.json
+++ b/Localization/ko-KR.json
@@ -23,6 +23,7 @@
     { "key": "ui.playerStatus.toggle", "value": "플레이어 상태 창 표시 (토글 키: {0})" },
     { "key": "ui.playerStatus.id", "value": "ID:" },
     { "key": "ui.playerStatus.name", "value": "이름:" },
+    { "key": "ui.playerStatus.ping", "value": "핑" },
     { "key": "ui.playerStatus.latency", "value": "지연 시간:" },
     { "key": "ui.playerStatus.inGame", "value": "게임 중:" },
     { "key": "ui.playerStatus.yes", "value": "예" },

--- a/Localization/pt-BR.json
+++ b/Localization/pt-BR.json
@@ -23,6 +23,7 @@
     { "key": "ui.playerStatus.toggle", "value": "Mostrar janela de status do jogador (Tecla: {0})" },
     { "key": "ui.playerStatus.id", "value": "ID:" },
     { "key": "ui.playerStatus.name", "value": "Nome:" },
+    { "key": "ui.playerStatus.ping", "value": "Ping" },
     { "key": "ui.playerStatus.latency", "value": "Latência:" },
     { "key": "ui.playerStatus.inGame", "value": "No jogo:" },
     { "key": "ui.playerStatus.yes", "value": "Sim" },

--- a/Localization/zh-CN.json
+++ b/Localization/zh-CN.json
@@ -23,6 +23,7 @@
     { "key": "ui.playerStatus.toggle", "value": "显示玩家状态窗口 (切换键: {0})" },
     { "key": "ui.playerStatus.id", "value": "ID:" },
     { "key": "ui.playerStatus.name", "value": "名称:" },
+    { "key": "ui.playerStatus.ping", "value": "延迟" },
     { "key": "ui.playerStatus.latency", "value": "延迟:" },
     { "key": "ui.playerStatus.inGame", "value": "游戏中:" },
     { "key": "ui.playerStatus.yes", "value": "是" },


### PR DESCRIPTION
## 概述
基于ISteamNetworkingSockets的混合P2P传输层。系统支持Steam和LAN两种传输模式的自动切换，同时保持与现有代码的完全向后兼容。

## 主要功能

### 1. 投票系统RPC框架
- 实现6个RPC方法：VoteStart、VoteRequest、VoteCast、VoteReadySet、VoteBeginLoad、VoteCancel
- 支持Steam和LAN双模式自动检测
- Steam模式使用SteamID作为参与者标识
- LAN模式使用IP:Port作为参与者标识
- 修复LAN环境下客户端白名单验证问题

### 2. 混合P2P传输层
- 新增HybridRPCManager，统一管理RPC调用
- 支持三种传输模式：
  - Auto：自动检测环境选择最佳传输方式
  - Steam：强制使用ISteamNetworkingSockets API
  - LAN：强制使用LiteNetLib UDP
- 实现SteamNetworkingTransport，完整支持ISteamNetworkingSockets
- 在Mod.OnNetworkReceive中集成LAN RPC消息处理

### 3. 网络增强功能
- NAT类型检测和显示（Open/Moderate/Strict/Blocked）
- 延迟计算和补偿系统
- 客户端数据包验证
- AI血量同步改进
- Steam头像缓存机制

### 4. UI改进
- 断开连接对话框移至屏幕底部
- 玩家状态窗口使用双行布局
- 添加完整的本地化支持
- 投票面板正确显示参与者信息
- 玩家状态提示steam头像(有问题)

## RPC使用教学

### 快速开始

#### 启用投票系统RPC模式

```csharp
// 在游戏初始化时
VoteSystemRPC.Instance.UseRPCMode = true;
HybridRPCManager.Instance.Mode = TransportMode.Auto;  // 推荐使用自动模式
```

#### 传输模式说明

**Auto模式（推荐）**
```csharp
HybridRPCManager.Instance.Mode = TransportMode.Auto;
```
- 自动检测当前环境
- Steam环境优先使用Steam传输
- LAN环境自动使用LAN传输
- 无需手动配置

**Steam模式**
```csharp
HybridRPCManager.Instance.Mode = TransportMode.Steam;
```
- 强制使用Steam传输
- 需要SteamManager已初始化
- 支持NAT穿透
- 适合互联网联机

**LAN模式**
```csharp
HybridRPCManager.Instance.Mode = TransportMode.LAN;
```
- 强制使用LAN传输
- 使用LiteNetLib UDP
- 不需要Steam
- 适合局域网联机

### 自定义RPC使用示例

系统已内置投票系统RPC，如需添加自定义RPC：

#### 1. 注册RPC处理器

```csharp
public class MyCustomRPC : MonoBehaviour
{
    private void Start()
    {
        var rpcManager = HybridRPCManager.Instance;
        if (rpcManager != null)
        {
            // 注册服务器端处理器
            rpcManager.RegisterRPC("MyRPCName", OnMyRPCReceived);
        }
    }
    
    private void OnMyRPCReceived(long senderConnectionId, NetDataReader reader)
    {
        // 读取数据
        string message = reader.GetString();
        int value = reader.GetInt();
        
        Debug.Log($"收到RPC: {message}, {value}");
    }
}
```

#### 2. 调用RPC

**客户端调用服务器**
```csharp
var rpcManager = HybridRPCManager.Instance;
if (rpcManager != null)
{
    rpcManager.CallRPC("MyRPCName", RPCTarget.Server, 0, (writer) =>
    {
        writer.Put("Hello Server");
        writer.Put(123);
    }, DeliveryMethod.ReliableOrdered);
}
```

**服务器广播到所有客户端**
```csharp
var rpcManager = HybridRPCManager.Instance;
if (rpcManager != null && rpcManager.IsServer)
{
    rpcManager.CallRPC("MyRPCName", RPCTarget.AllClients, 0, (writer) =>
    {
        writer.Put("Hello Clients");
        writer.Put(456);
    }, DeliveryMethod.ReliableOrdered);
}
```

### 工作流程

#### Steam模式流程
```
客户端 → HybridRPCManager.CallRPC()
         ↓
         SteamNetworkingTransport.ClientSend()
         ↓
         [Steam P2P网络]
         ↓
         SteamNetworkingTransport.ServerReceive()
         ↓
         RPC处理器被调用
```

#### LAN模式流程
```
客户端 → HybridRPCManager.CallRPC()
         ↓
         NetService.connectedPeer.Send()
         ↓
         [LiteNetLib UDP]
         ↓
         Mod.OnNetworkReceive()
         ↓
         HybridRPCManager.ProcessLANMessage()
         ↓
         RPC处理器被调用
```

## 向后兼容性

系统完全向后兼容：

- **默认行为**：`UseRPCMode = false`，使用传统NetDataWriter方式
- **启用RPC**：设置`UseRPCMode = true`后才使用新的RPC系统
- **传统模式**：所有现有代码无需修改即可继续工作
- **平滑升级**：可以逐步迁移到RPC模式



## 新增文件

- `EscapeFromDuckovCoopMod/Main/SceneService/VoteSystemRPC.cs
- `EscapeFromDuckovCoopMod/Net/HybridP2P/HybridRPCManager.cs
- `EscapeFromDuckovCoopMod/Net/HybridP2P/SteamNetworkingTransport.c
- `EscapeFromDuckovCoopMod/Net/HybridP2P/HybridP2PRelay.cs
- `EscapeFromDuckovCoopMod/Net/HybridP2P/HybridRPCExample.cs
- `EscapeFromDuckovCoopMod/Net/HybridP2P/NATDetector.cs`
- `EscapeFromDuckovCoopMod/Net/HybridP2P/LatencyCalculator.cs`
- `EscapeFromDuckovCoopMod/Net/HybridP2P/LatencyCompensator.cs`
- `EscapeFromDuckovCoopMod/Net/HybridP2P/HybridP2PValidator.cs`


## 代码统计
- 新增代码：约3914行
- 修改文件：30个
- 新增文件：9个
- 编译状态：成功，仅有原有的16个警告（非本PR引入）


## 注意事项

1. RPC模式需要手动启用，默认关闭
2. 混合P2P传输层需要Steam初始化（Steam模式）
3. 建议在实际使用前进行充分测试
4. 文档已包含完整的使用示例

## P2P混合传输与延迟补偿系统

混合P2P传输架构，可以根据实际网络环境自动选择最佳的传输方式，并配备延迟补偿机制确保流畅的游戏体验。

### 核心原理

系统提供两种传输通道：

**Steam P2P传输**
使用ISteamNetworkingSockets API，适用于互联网环境。具有内置的NAT穿透能力，可以在大多数网络环境下建立P2P连接。如果直连失败，Steam会自动使用中继服务器转发数据。

**LAN UDP传输**
使用LiteNetLib库的原生UDP传输，适用于局域网环境。延迟更低，性能更好，但仅限于同一网络内的设备。

### 工作机制

系统在运行时会检测当前环境：
- 检查Steam是否初始化
- 检测参与者的IP地址范围
- 判断是否存在Steam好友关系
- 测量实际网络延迟

根据检测结果，自动选择合适的传输方式。用户也可以手动指定传输模式。

### 延迟补偿机制

系统实现了完整的延迟补偿框架来解决网络延迟带来的不同步问题。

**延迟测量**
通过Ping-Pong机制持续测量每个客户端的往返时间。系统会记录最近多个样本，计算平均延迟，并在UI上实时显示。

**位置历史记录**
服务器和客户端都会记录玩家的位置历史，包括坐标、朝向和速度。历史记录保存最近2秒的数据，用于回溯计算。

**位置预测**
当收到远程玩家的位置更新时，系统根据测得的延迟值，结合历史速度数据，预测玩家此刻的实际位置。例如，如果延迟是100ms，系统会将收到的位置向前推算100ms。

**补偿限制**
为了防止出现不自然的瞬移，系统限制了最大补偿距离。如果计算出的补偿位置距离原始位置超过5米，系统会放弃补偿，使用原始位置。

**应用场景**
延迟补偿主要应用于：
- 玩家位置同步：让远程玩家的移动更流畅
- 射击命中判定：根据射击时的延迟回溯目标位置
- 动画同步：减少动作延迟感

### 传输模式

**自动模式**
系统自动判断。如果检测到Steam环境且参与者在好友列表中，使用Steam传输。如果检测到局域网IP地址，使用LAN传输。

**Steam模式**
强制使用Steam传输。要求所有参与者的Steam客户端已登录。适合跨网络联机。由于可能经过中继服务器，延迟通常在50-200ms之间，延迟补偿在此模式下尤为重要。

**LAN模式**
强制使用局域网传输。要求所有参与者在同一局域网内。延迟通常在10-50ms之间，延迟补偿可以进一步优化体验。

### NAT类型检测

系统通过STUN协议检测每个客户端的NAT类型：
- Open：无限制，可以直连任何对等端
- Moderate：部分限制，可以直连大多数对等端
- Strict：严格限制，只能连接Open和Moderate
- Blocked：完全阻断，必须使用中继

NAT类型会显示在玩家列表中，帮助诊断连接问题。

### 数据包验证

客户端发送的数据会经过服务器验证：
- 移动速度不能超过合理范围
- 射击频率不能超过武器限制
- 伤害值必须在武器参数范围内

异常数据会被拒绝，并记录可疑行为。多次违规的客户端会被踢出。

### 应用场景

投票系统使用该混合传输：
- 在Steam联机时，投票消息通过Steam P2P发送
- 在局域网直连时，投票消息通过UDP发送
- 参与者标识会根据传输方式自动调整（Steam使用SteamID，LAN使用IP地址）

位置同步使用延迟补偿：
- 每次收到位置更新时应用延迟补偿
- 根据实测延迟动态调整预测量
- 保持远程玩家移动的流畅性

### 兼容性

系统完全向后兼容现有代码。默认情况下使用传统的NetDataWriter方式。只有显式启用RPC模式后，才会激活混合传输系统。延迟补偿功能始终运行，不需要额外配置。


