### PR TITLE
fix: 修复场景投票系统无法显示其他玩家Steam名字的问题

### DIFF
--- a/EscapeFromDuckovCoopMod/Net/ClientStatusMessage.cs
+++ b/EscapeFromDuckovCoopMod/Net/ClientStatusMessage.cs
@@ -25,6 +25,10 @@ namespace EscapeFromDuckovCoopMod.Net;
 /// </summary>
 public static class ClientStatusMessage
 {
+    // 🆕 添加 SteamID -> SteamName 的映射缓存
+    private static System.Collections.Generic.Dictionary<string, string> _steamIdToNameMap = 
+        new System.Collections.Generic.Dictionary<string, string>();
+
     /// <summary>
     /// 客户端状态数据结构
     /// </summary>
@@ -117,6 +121,21 @@ public static class ClientStatusMessage
     }
 
     /// <summary>
+    /// 🆕 获取缓存的 Steam 名字（供 SceneVoteMessage 调用）
+    /// </summary>
+    public static string GetSteamNameFromSteamId(string steamId)
+    {
+        if (string.IsNullOrEmpty(steamId))
+            return "";
+
+        if (_steamIdToNameMap.TryGetValue(steamId, out var steamName))
+        {
+            return steamName;
+        }
+        return "";
+    }
+
+    /// <summary>
     /// 主机：处理客户端状态更新
     /// </summary>
     public static void Host_HandleClientStatus(NetPeer fromPeer, string json)
@@ -139,6 +158,15 @@ public static class ClientStatusMessage
             LoggerHelper.Log(
                 $"[ClientStatus] 收到客户端状态: EndPoint={data.endPoint}, SteamID={data.steamId}, SteamName={data.steamName}, Name={data.playerName}"
             );
+
+            // 🆕 缓存 SteamID -> SteamName 映射
+            if (!string.IsNullOrEmpty(data.steamId) && !string.IsNullOrEmpty(data.steamName))
+            {
+                _steamIdToNameMap[data.steamId] = data.steamName;
+                LoggerHelper.Log(
+                    $"[ClientStatus] ✓ 已缓存 Steam 名字映射: {data.steamId} -> {data.steamName}"
+                );
+            }
 
             // 🔧 建立 SteamID 和 EndPoint 的映射
             if (

--- a/EscapeFromDuckovCoopMod/Net/SceneVoteMessage.cs
+++ b/EscapeFromDuckovCoopMod/Net/SceneVoteMessage.cs
@@ -931,14 +931,30 @@ public static class SceneVoteMessage
                 return Steamworks.SteamFriends.GetPersonaName();
             }
 
-            // 🔧 从 SteamID 获取用户名
+            // 🆕 优先从 ClientStatusMessage 的缓存中获取
             var steamIdStr = GetSteamId(peer);
+            if (!string.IsNullOrEmpty(steamIdStr))
+            {
+                var cachedName = ClientStatusMessage.GetSteamNameFromSteamId(steamIdStr);
+                if (!string.IsNullOrEmpty(cachedName))
+                {
+                    LoggerHelper.Log(
+                        $"[SceneVote] 从缓存获取 Steam 名字: {steamIdStr} -> {cachedName}"
+                    );
+                    return cachedName;
+                }
+            }
+
+            // 🔧 备用方案：从 Steam API 获取用户名（可能失败，仅适用于好友）
             if (!string.IsNullOrEmpty(steamIdStr) && ulong.TryParse(steamIdStr, out var steamIdValue))
             {
                 var steamId = new Steamworks.CSteamID(steamIdValue);
                 var steamName = Steamworks.SteamFriends.GetFriendPersonaName(steamId);
                 if (!string.IsNullOrEmpty(steamName) && steamName != "[unknown]")
                 {
+                    LoggerHelper.Log(
+                        $"[SceneVote] 从 Steam API 获取名字: {steamIdStr} -> {steamName}"
+                    );
                     return steamName;
                 }
             }


### PR DESCRIPTION
问题描述：
- 投票界面只显示主机的Steam名字，其他玩家显示为空

根本原因：
1. GetSteamName依赖Steam API的GetFriendPersonaName()只能获取好友名字
2. ClientStatusMessage虽然接收了客户端上报的steamName，但没有缓存
3. GetSteamName没有从缓存读取，直接调用Steam API失败

修复方案：
1. 在ClientStatusMessage中添加SteamID->SteamName的缓存字典
2. 在Host_HandleClientStatus中缓存客户端上报的steamName
3. 修改GetSteamName优先从缓存读取，Steam API作为备用

影响范围：
- 所有使用投票系统的玩家
- 修复后可正确显示所有玩家的Steam名字（包括非好友）

测试：
- 编译成功（Release配置，0个错误）
- 部署成功（版本：EscapeFromDuckovCoopMod-20251110-1921）