### PR TITLE
修复主机主界面卡顿

### DIFF
--- a/EscapeFromDuckovCoopMod/Main/Health/HealthM.cs
+++ b/EscapeFromDuckovCoopMod/Main/Health/HealthM.cs
@@ -365,7 +365,7 @@ public class HealthM : MonoBehaviour
     {
         if (!IsServer || !networkStarted) return;
 
-        var hostMain = CharacterMainControl.Main;
+        var hostMain = FrameCache.Get(() => CharacterMainControl.Main);
         if (hostMain) HealthTool.Server_HookOneHealth(null, hostMain.gameObject);
 
         if (remoteCharacters != null)

--- a/EscapeFromDuckovCoopMod/Main/Loader/Mod.cs
+++ b/EscapeFromDuckovCoopMod/Main/Loader/Mod.cs
@@ -242,7 +242,7 @@ public partial class ModBehaviourF : MonoBehaviour
 
     private void Update()
     {
-        if (CharacterMainControl.Main != null && !isinit)
+        if (FrameCache.Get(() => CharacterMainControl.Main) != null && !isinit)
         {
             isinit = true;
             Traverse
@@ -288,7 +288,7 @@ public partial class ModBehaviourF : MonoBehaviour
             Cursor.lockState = CursorLockMode.None;
         }
 
-        if (CharacterMainControl.Main == null)
+        if (FrameCache.Get(() => CharacterMainControl.Main) == null)
             isinit = false;
 
         //if (ModUI.Instance != null && Input.GetKeyDown(KeyCode.Home)) ModUI.Instance.showUI = !ModUI.Instance.showUI;

--- a/EscapeFromDuckovCoopMod/Main/LocalPlayer/LocalPlayerManager.cs
+++ b/EscapeFromDuckovCoopMod/Main/LocalPlayer/LocalPlayerManager.cs
@@ -84,7 +84,7 @@ public class LocalPlayerManager : MonoBehaviour
         sceneId = null;
 
         // 1) LevelManager/主角存在才算“进了关卡”
-        var lm = LevelManager.Instance;
+        var lm = FrameCache.Get(() => LevelManager.Instance);
         if (lm == null || lm.MainCharacter == null)
         {
             return false;
@@ -297,9 +297,8 @@ public class LocalPlayerManager : MonoBehaviour
             return;
         }
 
-        var bool1 = ComputeIsInGame(out var ids);
-        var currentIsInGame = bool1;
-        var levelManager = LevelManager.Instance;
+        var currentIsInGame = ComputeIsInGame(out var ids);
+        var levelManager = FrameCache.Get(() => LevelManager.Instance);
 
         if (Service.localPlayerStatus.IsInGame != currentIsInGame)
         {

--- a/EscapeFromDuckovCoopMod/Main/LocalPlayer/SendLocalPlayerStatus.cs
+++ b/EscapeFromDuckovCoopMod/Main/LocalPlayer/SendLocalPlayerStatus.cs
@@ -80,7 +80,7 @@ public class SendLocalPlayerStatus : MonoBehaviour
     {
         if (localPlayerStatus == null || !networkStarted) return;
 
-        var main = CharacterMainControl.Main;
+        var main = FrameCache.Get(() => CharacterMainControl.Main);
         if (!main) return;
 
         var tr = main.transform;
@@ -139,7 +139,7 @@ public class SendLocalPlayerStatus : MonoBehaviour
     {
         if (!networkStarted) return;
 
-        var mainControl = CharacterMainControl.Main;
+        var mainControl = FrameCache.Get(() => CharacterMainControl.Main);
         if (mainControl == null) return;
 
         var model = mainControl.modelRoot.Find("0_CharacterModel_Custom_Template(Clone)");


### PR DESCRIPTION
在主界面创建主机会有较严重掉帧，原因是主机逻辑中大量调用了`LevelManager.Instance`，而主界面没有`LevelManager`，不巧的是这个getter在单例没有创建的时候会遍历场景树来寻找`LevelManager`实例，导致了和之前类似的问题。

简单写了个过滤器拦截一帧内对一个heavy method的重复调用（本来可以直接打patch到getter上，但是本体有地方会在加载后立刻调用所以会把游戏搞崩）。理论上这个对地图加载也有点作用，但是现在加载已经很快了感觉不出来（

没有找到合适的地方暂时放在`DeferedRunner`下面，有任何格式、功能或者别的问题戳我一下马上来改。