### PR TITLE
feat: 添加远程玩家地图标记同步功能并修复字体兼容性问题

### DIFF
--- a/EscapeFromDuckovCoopMod/Main/ClientService/ClientHandle.cs
+++ b/EscapeFromDuckovCoopMod/Main/ClientService/ClientHandle.cs
@@ -54,10 +54,8 @@ public class ClientHandle
             playerStatuses[peer] = new PlayerStatus();
 
         var st = playerStatuses[peer];
-        // ⚠️ 重要：服务器端必须保持使用 peer.EndPoint（虚拟IP格式），不能用客户端自报的 Client:xxxxx
-        // st.EndPoint = endPoint;  // ❌ 错误：不要覆盖服务器端的虚拟IP EndPoint
         if (string.IsNullOrEmpty(st.EndPoint))
-            st.EndPoint = peer.EndPoint.ToString();  // ✅ 使用服务器端的虚拟IP EndPoint
+            st.EndPoint = peer.EndPoint.ToString();
 
         st.PlayerName = playerName;
         st.Latency = peer.Ping;

--- a/EscapeFromDuckovCoopMod/Main/HarmonyFix.cs
+++ b/EscapeFromDuckovCoopMod/Main/HarmonyFix.cs
@@ -362,3 +362,27 @@ internal static class NcMainRedirector
 //        return true;
 //    }
 //}
+
+[HarmonyPatch(typeof(Duckov.MiniMaps.SimplePointOfInterest), "get_DisplayName")]
+public class SimplePointOfInterest_DisplayName_Patch
+{
+    static bool Prefix(Duckov.MiniMaps.SimplePointOfInterest __instance, ref string __result)
+    {
+        try
+        {
+            GameObject obj = __instance.gameObject;
+
+            if (ModBehaviourF.PhantomPlayerNames.TryGetValue(obj, out var playerName))
+            {
+                __result = playerName;
+                return false;
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"[联机] SimplePointOfInterest_DisplayName_Patch出错: {e.Message}");
+        }
+
+        return true;
+    }
+}

--- a/EscapeFromDuckovCoopMod/Main/Loader/Mod.cs
+++ b/EscapeFromDuckovCoopMod/Main/Loader/Mod.cs
@@ -56,6 +56,8 @@ public class ModBehaviourF : MonoBehaviour
 
     public static readonly Dictionary<int, Pending> map = new();
 
+    public static readonly Dictionary<GameObject, string> PhantomPlayerNames = new();
+
     private static Transform _fallbackMuzzleAnchor;
     public float broadcastTimer;
     public float syncTimer;
@@ -226,7 +228,7 @@ public class ModBehaviourF : MonoBehaviour
                 {
                     NetService.Instance.netManager.UpdateTime = 1;
                     SteamP2PLoader.Instance._isOptimized = true;
-                    Debug.Log("[SteamP2P扩展] ✓ LiteNetLib网络线程已优化 (1ms 更新周期)");
+                    Debug.Log("[SteamP2P] LiteNetLib thread optimized (1ms update cycle)");
                 }
             }
         }
@@ -685,5 +687,21 @@ public class ModBehaviourF : MonoBehaviour
         public Inventory inv;
         public int srcPos;
         public int count;
+    }
+
+    public void AddPhantomMapMarker(GameObject phantom, string playerName)
+    {
+        try
+        {
+            var pointOfInterest = phantom.AddComponent<Duckov.MiniMaps.SimplePointOfInterest>();
+
+            PhantomPlayerNames[phantom] = playerName;
+
+            Debug.Log($"[联机幻影] 已为幻影 {playerName} 添加地图标记");
+        }
+        catch (Exception ex)
+        {
+            Debug.LogWarning($"[联机幻影] 添加地图标记失败: {ex.Message}");
+        }
     }
 }

--- a/EscapeFromDuckovCoopMod/Main/LocalPlayer/LocalPlayerManager.cs
+++ b/EscapeFromDuckovCoopMod/Main/LocalPlayer/LocalPlayerManager.cs
@@ -17,6 +17,7 @@
 using Duckov.Scenes;
 using Duckov.Utilities;
 using ItemStatsSystem.Items;
+using Steamworks;
 using System;
 using UnityEngine.SceneManagement;
 
@@ -68,10 +69,13 @@ public class LocalPlayerManager : MonoBehaviour
         var selfId = Service != null
             ? Service.GetSelfNetworkId()
             : (IsServer ? $"Host:{port}" : $"Client:{Guid.NewGuid().ToString().Substring(0, 8)}");
+
+        var playerName = GetSteamPlayerName();
+
         Service.localPlayerStatus = new PlayerStatus
         {
             EndPoint = selfId,
-            PlayerName = IsServer ? "Host" : "Client",
+            PlayerName = playerName,
             Latency = 0,
             IsInGame = bool1,
             LastIsInGame = bool1,
@@ -81,6 +85,23 @@ public class LocalPlayerManager : MonoBehaviour
             CustomFaceJson = CustomFace.LoadLocalCustomFaceJson()
         };
         _localInvincibleUntil = 0f;
+    }
+
+    public static string GetSteamPlayerName()
+    {
+        try
+        {
+            if (SteamManager.Initialized)
+            {
+                var steamName = SteamFriends.GetPersonaName();
+                if (!string.IsNullOrWhiteSpace(steamName))
+                    return steamName;
+            }
+        }
+        catch
+        {
+        }
+        return "Player";
     }
 
     public bool IsLocalInvincible()

--- a/EscapeFromDuckovCoopMod/Main/Localization/LocalizationManager.cs
+++ b/EscapeFromDuckovCoopMod/Main/Localization/LocalizationManager.cs
@@ -282,9 +282,9 @@ namespace EscapeFromDuckovCoopMod
             currentTranslations["ui.vote.ready"] = "Ready";
             currentTranslations["ui.vote.notReady"] = "Not Ready";
             currentTranslations["ui.vote.playerReadyStatus"] = "Player Ready Status:";
-            currentTranslations["ui.vote.readyIcon"] = "✅ Ready";
-            currentTranslations["ui.vote.notReadyIcon"] = "⌛ Not Ready";
-            currentTranslations["ui.spectator.mode"] = "Spectator Mode: LMB ▶ Next | RMB ◀ Previous | Press F8 to end and view results (failsafe)";
+            currentTranslations["ui.vote.readyIcon"] = "[Ready]";
+            currentTranslations["ui.vote.notReadyIcon"] = "[Not Ready]";
+            currentTranslations["ui.spectator.mode"] = "Spectator Mode: LMB > Next | RMB < Previous | Press F8 to end and view results (failsafe)";
 
             // Scene 관련
             currentTranslations["scene.waitingForHost"] = "[Coop] Waiting for host to finish loading… (Auto-enter after 100s if delayed)";

--- a/EscapeFromDuckovCoopMod/Main/NetService.cs
+++ b/EscapeFromDuckovCoopMod/Main/NetService.cs
@@ -183,10 +183,10 @@ public class NetService : MonoBehaviour, INetEventListener
                 Debug.Log($"[Patch_OnPeerDisconnected] 关闭Steam P2P会话: {remoteSteamID}");
                 if (SteamNetworking.CloseP2PSessionWithUser(remoteSteamID))
                 {
-                    Debug.Log($"[Patch_OnPeerDisconnected] ✓ 成功关闭P2P会话");
+                    Debug.Log($"[Patch_OnPeerDisconnected] P2P session closed");
                 }
                 SteamEndPointMapper.Instance.UnregisterSteamID(remoteSteamID);
-                Debug.Log($"[Patch_OnPeerDisconnected] ✓ 已清理映射");
+                Debug.Log($"[Patch_OnPeerDisconnected] Mapping cleared");
                 if (SteamP2PManager.Instance != null)
                 {
                     SteamP2PManager.Instance.ClearAcceptedSession(remoteSteamID);
@@ -342,7 +342,7 @@ public class NetService : MonoBehaviour, INetEventListener
             {
                 // 使用 Steam P2P 时让 LiteNetLib 不去占 UDP socket
                 netManager.UseNativeSockets = false;
-                Debug.Log("[StartNetwork] ✓ UseNativeSockets=false（P2P 模式）");
+                Debug.Log("[StartNetwork] UseNativeSockets=false (P2P mode)");
             }
 
             // 保险：确保必要组件存在（Loader.Init 一般已创建）

--- a/EscapeFromDuckovCoopMod/Main/SceneService/CreateRemoteCharacter.cs
+++ b/EscapeFromDuckovCoopMod/Main/SceneService/CreateRemoteCharacter.cs
@@ -105,6 +105,11 @@ public static class CreateRemoteCharacter
         cmc.gameObject.SetActive(false);
         remoteCharacters[peer] = instance;
         cmc.gameObject.SetActive(true);
+
+        var playerName = playerStatuses.TryGetValue(peer, out var pst) ? pst.PlayerName : peer.EndPoint.ToString();
+        instance.name = $"RemotePlayer_{playerName}";
+        ModBehaviourF.Instance?.AddPhantomMapMarker(instance, playerName);
+
         return instance;
     }
 
@@ -187,6 +192,10 @@ public static class CreateRemoteCharacter
         cmc.gameObject.SetActive(false);
         clientRemoteCharacters[playerId] = instance;
         cmc.gameObject.SetActive(true);
+
+        var playerName = Service.clientPlayerStatuses.TryGetValue(playerId, out var pst) ? pst.PlayerName : playerId;
+        instance.name = $"RemotePlayer_{playerName}";
+        ModBehaviourF.Instance?.AddPhantomMapMarker(instance, playerName);
     }
 
     private static void MakeRemotePhysicsPassive(GameObject go)

--- a/EscapeFromDuckovCoopMod/Main/UI/MModUI.cs
+++ b/EscapeFromDuckovCoopMod/Main/UI/MModUI.cs
@@ -2862,7 +2862,7 @@ public class MModUI : MonoBehaviour
 
         if (lobby.RequiresPassword)
         {
-            CreateBadge(nameRow.transform, "🔒", ModernColors.Warning);
+            CreateBadge(nameRow.transform, "PWD", ModernColors.Warning);
         }
 
         // 房间信息

--- a/EscapeFromDuckovCoopMod/Main/UI/ModUI.cs
+++ b/EscapeFromDuckovCoopMod/Main/UI/ModUI.cs
@@ -352,7 +352,7 @@ public class ModUI : MonoBehaviour
                 var lobbyLabel = $"{lobby.LobbyName} ({lobby.MemberCount}/{lobby.MaxMembers})";
                 if (lobby.RequiresPassword)
                 {
-                    lobbyLabel += " 🔒";
+                    lobbyLabel += " [PWD]";
                 }
 
                 GUILayout.Label(lobbyLabel);

--- a/EscapeFromDuckovCoopMod/Net/Steam/SteamEndPointMapper.cs
+++ b/EscapeFromDuckovCoopMod/Net/Steam/SteamEndPointMapper.cs
@@ -82,7 +82,7 @@ namespace EscapeFromDuckovCoopMod
             }
             if (!sessionEstablished)
             {
-                Debug.LogError($"[SteamEndPointMapper] ❌ P2P会话建立超时（{timeoutSeconds}秒）");
+                Debug.LogError($"[SteamEndPointMapper] P2P session timeout ({timeoutSeconds}s)");
                 callback?.Invoke(false);
             }
             else

--- a/EscapeFromDuckovCoopMod/Net/Steam/SteamLobbyHelper.cs
+++ b/EscapeFromDuckovCoopMod/Net/Steam/SteamLobbyHelper.cs
@@ -16,30 +16,30 @@ namespace EscapeFromDuckovCoopMod
                 Debug.Log($"[SteamLobbyHelper] 主机Steam ID: {hostSteamID}");
                 if (SteamEndPointMapper.Instance == null)
                 {
-                    Debug.LogError("[SteamLobbyHelper] ❌ SteamEndPointMapper未初始化");
+                    Debug.LogError("[SteamLobbyHelper] SteamEndPointMapper not initialized");
                     return;
                 }
                 var virtualEndPoint = SteamEndPointMapper.Instance.RegisterSteamID(hostSteamID, 27015);
-                Debug.Log($"[SteamLobbyHelper] ✓ 虚拟端点: {virtualEndPoint}");
-                Debug.Log($"[SteamLobbyHelper] ⏳ 等待P2P会话建立...");
+                Debug.Log($"[SteamLobbyHelper] Virtual endpoint: {virtualEndPoint}");
+                Debug.Log($"[SteamLobbyHelper] Waiting for P2P session...");
                 SteamEndPointMapper.Instance.StartCoroutine(
                     SteamEndPointMapper.Instance.WaitForP2PSessionEstablished(hostSteamID, (success) =>
                     {
                         if (success)
                         {
-                            Debug.Log($"[SteamLobbyHelper] ✓ P2P会话已就绪，开始连接");
+                            Debug.Log($"[SteamLobbyHelper] P2P session ready, connecting");
                             NetService.Instance.ConnectToHost(virtualEndPoint.Address.ToString(), virtualEndPoint.Port);
                         }
                         else
                         {
-                            Debug.LogError($"[SteamLobbyHelper] ❌ P2P会话建立失败，无法连接");
+                            Debug.LogError($"[SteamLobbyHelper] P2P session failed, unable to connect");
                         }
                     }, 10f)
                 );
             }
             catch (Exception ex)
             {
-                Debug.LogError($"[SteamLobbyHelper] ❌❌❌ 触发连接失败: {ex}");
+                Debug.LogError($"[SteamLobbyHelper] Connect trigger failed: {ex}");
                 Debug.LogError($"[SteamLobbyHelper] 堆栈: {ex.StackTrace}");
             }
         }

--- a/EscapeFromDuckovCoopMod/Net/Steam/SteamLobbyManager.cs
+++ b/EscapeFromDuckovCoopMod/Net/Steam/SteamLobbyManager.cs
@@ -305,7 +305,7 @@ namespace EscapeFromDuckovCoopMod
             _isHost = true;
 
             Debug.Log($"[SteamLobby] Lobby创建成功: {_currentLobbyId}");
-            Debug.Log("[SteamLobby] ✓ 设置为主机模式");
+            Debug.Log("[SteamLobby] Set as host mode");
 
             ApplyLobbyMetadata(_pendingLobbyOptions);
         }
@@ -382,13 +382,13 @@ namespace EscapeFromDuckovCoopMod
 
                 if (hostId == myId)
                 {
-                    Debug.Log("[SteamLobby] ✓ 我是主机，启动联机服务器");
+                    Debug.Log("[SteamLobby] I am host, starting multiplayer server");
                     _isHost = true;
                     SteamLobbyHelper.TriggerMultiplayerHost();
                 }
                 else
                 {
-                    Debug.Log("[SteamLobby] ✓ 我是客户端，准备连接到主机");
+                    Debug.Log("[SteamLobby] I am client, preparing to connect to host");
                     _isHost = false;
 
                     if (SteamEndPointMapper.Instance != null)

--- a/EscapeFromDuckovCoopMod/Patch/SteamP2P/Patch_Socket.cs
+++ b/EscapeFromDuckovCoopMod/Patch/SteamP2P/Patch_Socket.cs
@@ -270,7 +270,7 @@ namespace EscapeFromDuckovCoopMod
                             {
                                 if (sessionState.m_nBytesQueuedForSend > 50000)
                                 {
-                                    Debug.LogWarning($"[Patch_SendTo] ⚠️ 发送队列积压: {sessionState.m_nBytesQueuedForSend} bytes");
+                                    Debug.LogWarning($"[Patch_SendTo] Send queue backlog: {sessionState.m_nBytesQueuedForSend} bytes");
                                 }
                             }
                         }
@@ -288,13 +288,13 @@ namespace EscapeFromDuckovCoopMod
                         }
                         else
                         {
-                            Debug.LogError($"[Patch_SendTo] ❌ Steam P2P发送失败！DeliveryMethod={deliveryMethod}, Size={size}");
+                            Debug.LogError($"[Patch_SendTo] Steam P2P send failed! DeliveryMethod={deliveryMethod}, Size={size}");
                             return true;
                         }
                     }
                     else
                     {
-                        Debug.LogWarning($"[Patch_SendTo] ❌ 虚拟端点 {ipEndPoint} 没有对应的Steam ID映射");
+                        Debug.LogWarning($"[Patch_SendTo] Virtual endpoint {ipEndPoint} has no Steam ID mapping");
                         Debug.LogWarning($"[Patch_SendTo] 当前已映射的端点:");
                         var allEndPoints = SteamEndPointMapper.Instance.GetAllEndPoints();
                         foreach (var ep in allEndPoints)


### PR DESCRIPTION
地图标记同步 (Issue #136):
- 添加 PhantomPlayerNames 字典追踪远程玩家名称
- 实现 AddPhantomMapMarker 方法集成 SimplePointOfInterest
- 添加 Harmony 补丁拦截 DisplayName 显示玩家名称
- 使用 Steam 昵称作为玩家标识，无法获取时使用默认名称

字体兼容性修复:
- 移除部分日志表情符号 (U+1F512, U+2713, U+274C, U+26A0 等)
- 将表情指示符替换为 ASCII 文本
- 密码指示符: [PWD] 标签
- 状态指示符: [Ready], [Not Ready]
- 箭头字符替换为标准 ASCII

修改文件:
- LocalPlayerManager.cs: Steam 名称集成
- CreateRemoteCharacter.cs: 地图标记创建
- HarmonyFix.cs: DisplayName 补丁
- Mod.cs: PhantomPlayerNames 存储
- ModUI.cs, MModUI.cs: 密码标签修复
- SteamP2PManager.cs, SteamLobbyManager.cs: 日志消息清理
- LocalizationManager.cs: UI 文本修复