### PR TITLE
Fix rpc message id for dead client loot message

### DIFF
--- a/EscapeFromDuckovCoopMod/Main/Health/HealthM.cs
+++ b/EscapeFromDuckovCoopMod/Main/Health/HealthM.cs
@@ -44,6 +44,8 @@ public class HealthM : MonoBehaviour
     private float _cliNextSendHp;
     private float _cliNextHeartbeat;
 
+    private bool _clientDeathReported = false;
+
     private NetService Service => NetService.Instance;
     private bool IsServer => Service != null && Service.IsServer;
     private bool networkStarted => Service != null && Service.networkStarted;
@@ -92,6 +94,13 @@ public class HealthM : MonoBehaviour
         Debug.Log($"Client_SendSnapshot {health.CurrentHealth} max:{health.MaxHealth}");
         var now = Time.time;
         force |= damage.HasValue;
+
+        if (cur > 0f && _clientDeathReported)
+        {
+            // Reset lock when player is alive again (e.g. after respawn)
+            _clientDeathReported = false;
+        }
+
         if (!force)
         {
             if (Mathf.Approximately(max, _cliLastSentHp.max) && Mathf.Approximately(cur, _cliLastSentHp.cur))
@@ -110,6 +119,60 @@ public class HealthM : MonoBehaviour
 
         _cliLastSentHp = (max, cur);
         _cliNextSendHp = now + CLIENT_SEND_INTERVAL;
+
+        if(cur < 0f && !_clientDeathReported)
+        {
+            // Lock to avoid sending multiple death reports before player respawns
+            _clientDeathReported = true;
+            Client_SendDeadLoot();
+        }
+    }
+
+    private void Client_SendDeadLoot()
+    {
+        var w = new NetDataWriter();
+        w.Put((byte)Op.PLAYER_DEAD_LOOT_SPAWN);
+
+        Debug.Log($"[Client Report Dead] Writing Op: {(byte)Op.PLAYER_DEAD_LOOT_SPAWN}");
+
+        var main = CharacterMainControl.Main;
+        w.PutV3cm(main.transform.position);
+        var inventory = CharacterMainControl.Main.CharacterItem.Inventory;
+        var equipedItems = new[]
+        {
+            CharacterMainControl.Main.PrimWeaponSlot().Content,
+            CharacterMainControl.Main.SecWeaponSlot().Content,
+            CharacterMainControl.Main.HelmatSlot().Content,
+            CharacterMainControl.Main.ArmorSlot().Content,
+            CharacterMainControl.Main.GetSlot(CharacterEquipmentController.faceMaskHash).Content,
+            CharacterMainControl.Main.GetSlot(CharacterEquipmentController.headsetHash).Content,
+            CharacterMainControl.Main.BackpackSlot().Content
+        };
+        var items = new List<Item>();
+        
+        foreach (var item in equipedItems)
+        {
+            if (item != null) items.Add(item);
+        }
+
+        if (inventory != null)
+        {
+            foreach (var item in inventory)
+            {
+                if (item != null) items.Add(item);
+            }
+        }
+
+        Debug.Log($"Sending {items.Count} items to server");
+
+        w.Put(items.Count);
+        foreach (var item in items)
+        {
+            ItemTool.WriteItemSnapshot(w, ItemTool.MakeSnapshot(item));
+        }
+    
+        CoopTool.SendReliable(w);
+        Debug.Log($"Reporting Death message to server!");
     }
 
     private void Server_BroadcastHostSnapshot(Health health, DamageInfo? damage)

--- a/EscapeFromDuckovCoopMod/Main/Loader/Mod.cs
+++ b/EscapeFromDuckovCoopMod/Main/Loader/Mod.cs
@@ -589,6 +589,12 @@ public class ModBehaviourF : MonoBehaviour
             case Op.LOOT_DENY:
                 break;
 
+            case Op.PLAYER_DEAD_LOOT_SPAWN:
+            {
+                if (!IsServer) break;
+                COOPManager.LootNet.Server_HandlePlayerDeathWithInventory(reader);
+                break;
+            }
 
             case Op.LOOT_REQ_SPLIT:
                 {

--- a/EscapeFromDuckovCoopMod/Main/Op.cs
+++ b/EscapeFromDuckovCoopMod/Main/Op.cs
@@ -64,6 +64,7 @@ public enum Op : byte
     AI_STATE_UPDATE = 216,
     AI_ACTIVATION_STATE = 217,
 
+    PLAYER_DEAD_LOOT_SPAWN = 244, // Used to propage client death messages.
     DEAD_LOOT_DESPAWN = 247, // 主机 -> 客户端：AI 死亡掉落的箱子被移除（可选，先不强制使用）
     DEAD_LOOT_SPAWN = 248, // 主机 -> 客户端：AI 死亡掉落箱子生成（包含 scene 与变换）
 

--- a/EscapeFromDuckovCoopMod/Main/SceneService/LootNet.cs
+++ b/EscapeFromDuckovCoopMod/Main/SceneService/LootNet.cs
@@ -123,6 +123,117 @@ namespace EscapeFromDuckovCoopMod;
         _srvHookedItems.Clear();
     }
 
+    public void Server_HandlePlayerDeathWithInventory(NetPacketReader reader)
+    {
+        var pos = reader.GetV3cm();
+
+        var itemCount = reader.GetInt();
+        var itemSnapshots = new List<ItemSnapshot>();
+        
+        for (int i = 0; i < itemCount; i++)
+        {
+            try
+            {
+                var snap = ItemTool.ReadItemSnapshot(reader);
+                itemSnapshots.Add(snap);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[DEATH] Error reading item {i}: {ex}");
+            }
+        }
+        
+        Debug.Log($"[DEATH] Read {itemSnapshots.Count} item snapshots from client");
+        
+        // NOW spawn with the pre-read data
+        Server_SpawnDeadPlayerLoot(pos, itemSnapshots);
+    }
+
+    private async void Server_SpawnDeadPlayerLoot(Vector3 position, List<ItemSnapshot> itemSnapshots)
+    {
+        try
+        {            
+            // Get the loot box prefab
+            var prefab = LootManager.Instance.ResolveDeadLootPrefabOnServer();
+            if (!prefab)
+            {
+                Debug.LogError("[DEATH] Cannot find loot box prefab!");
+                return;
+            }
+            
+            // Spawn the loot container
+            var lootObj = GameObject.Instantiate(prefab.gameObject, position, Quaternion.identity);
+
+            var lootBox = lootObj.GetComponent<InteractableLootbox>();
+            if (!lootBox)
+            {
+                Debug.LogError("[DEATH] Spawned object doesn't have InteractableLootbox!");
+                GameObject.Destroy(lootObj);
+                return;
+            }
+            
+            var inventory = lootBox.Inventory;
+            if (!inventory)
+            {
+                Debug.LogError("[DEATH] Loot box doesn't have inventory!");
+                GameObject.Destroy(lootObj);
+                return;
+            }
+
+            var itemCount = itemSnapshots.Count;
+            Debug.Log($"[DEATH] Spawning loot at {position} with {itemCount} items");
+            
+            inventory.SetCapacity(Mathf.Max(itemCount, 10));
+            
+            for (int i = 0; i < itemCount; i++)
+            {
+                try
+                {
+                    var snap = itemSnapshots[i];
+                    var tmpItem = await ItemAssetsCollection.InstantiateAsync(snap.TypeId);
+                    ItemTool.ApplySnapshot(tmpItem, snap);
+                    inventory.AddItem(tmpItem);
+                }
+                catch (Exception ex)
+                {
+                    Debug.LogError($"[DEATH] Error creating item {i}: {ex}");
+                }
+            }
+            
+            // Register the loot box
+            var posKey = LootManager.Instance.ComputeLootKey(lootObj.transform);
+            Debug.Log($"[DEATH] Computed position key: {posKey}");
+            
+            if (posKey != 0)
+            {
+                CoopSyncDatabase.Loot.Register(lootBox, inventory);
+                Debug.Log($"[DEATH] Registered in CoopSyncDatabase");
+            }
+            
+            // Also register in InteractableLootbox.Inventories
+            try
+            {
+                var dict = InteractableLootbox.Inventories;
+                if (dict != null && posKey != 0)
+                {
+                    dict[posKey] = inventory;
+                    Debug.Log($"[DEATH] Registered in InteractableLootbox.Inventories");
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"[DEATH] Could not register in InteractableLootbox.Inventories: {ex}");
+            }
+            
+            Debug.Log($"[DEATH] Loot container spawned successfully!");
+            
+        }
+        catch (Exception ex)
+        {
+            Debug.LogError($"[DEATH] FATAL Error spawning loot: {ex}");
+        }
+    }    
+
     private int NextVersion(Inventory inv)
     {
         if (IsServer)


### PR DESCRIPTION
@InitLoader thanks for updating repository. 

Most of the changes were compatible with the new version. I had to change rpc message_id which was conflicting with env bool. Tested on top of v1.2.1 and its working working correctly. 
