### PR TITLE
fix: blue and red ball drops on client

### DIFF
--- a/EscapeFromDuckovCoopMod/Main/Item/ItemTool.cs
+++ b/EscapeFromDuckovCoopMod/Main/Item/ItemTool.cs
@@ -201,12 +201,25 @@ public static class ItemTool
 
             try
             {
+                bool hasQuest = false;
+                // Itemid 1411-1412 have both "Quest" and "Special" tags, but 
+                // its usable item and wasn't visible to client at all.
+                bool hasSpecial = false; 
+                
                 foreach (var tag in tags)
                 {
                     var name = tag?.name;
-                    if (!string.IsNullOrEmpty(name) && name.IndexOf("Quest", QuestTagComparison) >= 0)
-                        return true;
+                    if (string.IsNullOrEmpty(name)) continue;
+                    
+                    if (name.IndexOf("Quest", QuestTagComparison) >= 0)
+                        hasQuest = true;
+                    
+                    if (name.IndexOf("Special", QuestTagComparison) >= 0)
+                        hasSpecial = true;
                 }
+                
+                // Return true only if has Quest but NOT Special
+                return hasQuest && !hasSpecial;
             }
             catch
             {


### PR DESCRIPTION
Item ids: 1411 and 1412 `Red Ball`, `Blue Ball` is not visible on client.
- Not available as npc loot.
- Not available as dropped out from server inventory. 

```
[SERVER DROP] Registering drop:
  - Item: Blue Ball
  - TypeID: 1411
  - Position: (-7.31, 0.02, -73.88)
  - CreateRigidbody: True
  - QuestTag: True
  - Tags: [Quest, Special, Gem_Armor_Fleeze, NotNested]


[SERVER DROP] Registering drop:
  - Item: Red Ball
  - TypeID: 1412
  - Position: (-7.31, 0.02, -73.88)
  - CreateRigidbody: True
  - QuestTag: True
  - Tags: [Quest, Special, Gem_Armor_Igny, NotNested]
```

Since both items contains Quest tag its skipped in mod logic. Pr is fixing it. Tested on game version 2.2 and latest mod.